### PR TITLE
Chapter 8 - Baselines using NIXTLA

### DIFF
--- a/notebooks/Chapter08/00-Single Step Backtesting Baselines Nixtla.ipynb
+++ b/notebooks/Chapter08/00-Single Step Backtesting Baselines Nixtla.ipynb
@@ -1,0 +1,15103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b25018c9-2624-434c-aa23-04be1d73e729",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\tacke\\OneDrive\\Documents\\GitHub\\Modern-Time-Series-Forecasting-with-Python-2E-1\n"
+     ]
+    }
+   ],
+   "source": [
+    "%cd ../.."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "4f023467-970a-461e-a60f-7a66fce6a497",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import time\n",
+    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
+    "import os\n",
+    "import plotly.io as pio\n",
+    "pio.templates.default = \"plotly_white\"\n",
+    "\n",
+    "from pathlib import Path\n",
+    "from tqdm.autonotebook import tqdm\n",
+    "import warnings\n",
+    "import humanize\n",
+    "\n",
+    "\n",
+    "from statsforecast.core import StatsForecast\n",
+    "from utilsforecast.plotting import plot_series\n",
+    "from utilsforecast.evaluation import evaluate\n",
+    "from utilsforecast.losses import *\n",
+    "from statsforecast.models import (\n",
+    "    Naive,\n",
+    "    SeasonalNaive,\n",
+    "    HoltWinters,\n",
+    "    ETS,\n",
+    "    AutoETS,\n",
+    "    ARIMA,\n",
+    "    Theta,\n",
+    "    TBATS,\n",
+    "    MSTL\n",
+    "\n",
+    ")\n",
+    "\n",
+    "from functools import partial\n",
+    "from src.utils.ts_utils import forecast_bias_aggregate, forecast_bias_NIXTLA\n",
+    "from src.utils.general import LogTime\n",
+    "from src.utils import plotting_utils\n",
+    "from IPython.display import display, HTML\n",
+    "# %load_ext autoreload\n",
+    "# %autoreload 2\n",
+    "np.random.seed(42)\n",
+    "tqdm.pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f9a66dd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'NIXTLA_ID_AS_COL' in os.environ:\n",
+    "    del os.environ['NIXTLA_ID_AS_COL']\n",
+    "os.environ['NIXTLA_ID_AS_COL'] = '1'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "41ae72a1-3721-4b36-b211-b78d4b09c855",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"imgs/chapter_7\", exist_ok=True)\n",
+    "preprocessed = Path(\"data/london_smart_meters/preprocessed\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8900cd43-718f-4dc1-ace9-ef9dc99b600d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def format_plot(fig, legends = None, xlabel=\"Time\", ylabel=\"Value\", title=\"\"):\n",
+    "    if legends:\n",
+    "        names = cycle(legends)\n",
+    "        fig.for_each_trace(lambda t:  t.update(name = next(names)))\n",
+    "    fig.update_layout(\n",
+    "            autosize=False,\n",
+    "            width=900,\n",
+    "            height=500,\n",
+    "            title_text=title,\n",
+    "            title={\n",
+    "            'x':0.5,\n",
+    "            'xanchor': 'center',\n",
+    "            'yanchor': 'top'},\n",
+    "            titlefont={\n",
+    "                \"size\": 20\n",
+    "            },\n",
+    "            legend_title = None,\n",
+    "            yaxis=dict(\n",
+    "                title_text=ylabel,\n",
+    "                titlefont=dict(size=12),\n",
+    "            ),\n",
+    "            xaxis=dict(\n",
+    "                title_text=xlabel,\n",
+    "                titlefont=dict(size=12),\n",
+    "            )\n",
+    "        )\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4716f3d0-9ec6-4cfa-b345-fe93885543a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train Min and Max Date 2012-01-01 00:00:00 2013-12-31 23:30:00\n",
+      "Val Min and Max Date 2014-01-01 00:00:00 2014-01-31 23:30:00\n",
+      "Test Min and Max Date 2014-02-01 00:00:00 2014-02-27 23:30:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Readin the missing value imputed and train test split data\n",
+    "try:\n",
+    "    train_df = pd.read_parquet(preprocessed/\"selected_blocks_train_missing_imputed.parquet\")\n",
+    "    val_df = pd.read_parquet(preprocessed/\"selected_blocks_val_missing_imputed.parquet\")\n",
+    "    test_df = pd.read_parquet(preprocessed/\"selected_blocks_test_missing_imputed.parquet\")\n",
+    "\n",
+    "    print(\"Train Min and Max Date\",train_df.timestamp.min(), train_df.timestamp.max())\n",
+    "    print(\"Val Min and Max Date\",val_df.timestamp.min(), val_df.timestamp.max())\n",
+    "    print(\"Test Min and Max Date\",test_df.timestamp.min(), test_df.timestamp.max())\n",
+    "except FileNotFoundError:\n",
+    "    display(HTML(\"\"\"\n",
+    "    <div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Warning!</b> File not found. Please make sure you have run 01-Feature Engineering.ipynb in Chapter06\n",
+    "    </div>\n",
+    "    \"\"\"))\n",
+    "    \n",
+    "# # #Choosing a smaller backtesting window because of runtime issues\n",
+    "# backtesting = test_df[test_df.timestamp.between(pd.Timestamp(\"2014-01-01\"),pd.Timestamp(\"2014-01-08\"))]\n",
+    "# print(\"Backtesting DF Min and Max Date\",backtesting.timestamp.min(), backtesting.timestamp.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6046a8fe-283d-4f4b-ab1f-a5b23bad55e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "150"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(train_df.LCLid.unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3c6968e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>energy_consumption</th>\n",
+       "      <th>frequency</th>\n",
+       "      <th>series_length</th>\n",
+       "      <th>stdorToU</th>\n",
+       "      <th>Acorn</th>\n",
+       "      <th>Acorn_grouped</th>\n",
+       "      <th>file</th>\n",
+       "      <th>holidays</th>\n",
+       "      <th>...</th>\n",
+       "      <th>windBearing</th>\n",
+       "      <th>temperature</th>\n",
+       "      <th>dewPoint</th>\n",
+       "      <th>pressure</th>\n",
+       "      <th>apparentTemperature</th>\n",
+       "      <th>windSpeed</th>\n",
+       "      <th>precipType</th>\n",
+       "      <th>icon</th>\n",
+       "      <th>humidity</th>\n",
+       "      <th>summary</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2012-04-21 00:00:00</td>\n",
+       "      <td>MAC000768</td>\n",
+       "      <td>0.844</td>\n",
+       "      <td>30min</td>\n",
+       "      <td>32544</td>\n",
+       "      <td>Std</td>\n",
+       "      <td>ACORN-A</td>\n",
+       "      <td>Affluent</td>\n",
+       "      <td>block_1</td>\n",
+       "      <td>NO_HOLIDAY</td>\n",
+       "      <td>...</td>\n",
+       "      <td>251</td>\n",
+       "      <td>6.42</td>\n",
+       "      <td>3.54</td>\n",
+       "      <td>994.960022</td>\n",
+       "      <td>3.79</td>\n",
+       "      <td>3.64</td>\n",
+       "      <td>rain</td>\n",
+       "      <td>partly-cloudy-night</td>\n",
+       "      <td>0.82</td>\n",
+       "      <td>Partly Cloudy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2012-04-21 00:30:00</td>\n",
+       "      <td>MAC000768</td>\n",
+       "      <td>0.265</td>\n",
+       "      <td>30min</td>\n",
+       "      <td>32544</td>\n",
+       "      <td>Std</td>\n",
+       "      <td>ACORN-A</td>\n",
+       "      <td>Affluent</td>\n",
+       "      <td>block_1</td>\n",
+       "      <td>NO_HOLIDAY</td>\n",
+       "      <td>...</td>\n",
+       "      <td>251</td>\n",
+       "      <td>6.42</td>\n",
+       "      <td>3.54</td>\n",
+       "      <td>994.960022</td>\n",
+       "      <td>3.79</td>\n",
+       "      <td>3.64</td>\n",
+       "      <td>rain</td>\n",
+       "      <td>partly-cloudy-night</td>\n",
+       "      <td>0.82</td>\n",
+       "      <td>Partly Cloudy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2012-04-21 01:00:00</td>\n",
+       "      <td>MAC000768</td>\n",
+       "      <td>0.262</td>\n",
+       "      <td>30min</td>\n",
+       "      <td>32544</td>\n",
+       "      <td>Std</td>\n",
+       "      <td>ACORN-A</td>\n",
+       "      <td>Affluent</td>\n",
+       "      <td>block_1</td>\n",
+       "      <td>NO_HOLIDAY</td>\n",
+       "      <td>...</td>\n",
+       "      <td>251</td>\n",
+       "      <td>6.20</td>\n",
+       "      <td>3.61</td>\n",
+       "      <td>994.979980</td>\n",
+       "      <td>3.67</td>\n",
+       "      <td>3.42</td>\n",
+       "      <td>rain</td>\n",
+       "      <td>partly-cloudy-night</td>\n",
+       "      <td>0.83</td>\n",
+       "      <td>Partly Cloudy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2012-04-21 01:30:00</td>\n",
+       "      <td>MAC000768</td>\n",
+       "      <td>0.234</td>\n",
+       "      <td>30min</td>\n",
+       "      <td>32544</td>\n",
+       "      <td>Std</td>\n",
+       "      <td>ACORN-A</td>\n",
+       "      <td>Affluent</td>\n",
+       "      <td>block_1</td>\n",
+       "      <td>NO_HOLIDAY</td>\n",
+       "      <td>...</td>\n",
+       "      <td>251</td>\n",
+       "      <td>6.20</td>\n",
+       "      <td>3.61</td>\n",
+       "      <td>994.979980</td>\n",
+       "      <td>3.67</td>\n",
+       "      <td>3.42</td>\n",
+       "      <td>rain</td>\n",
+       "      <td>partly-cloudy-night</td>\n",
+       "      <td>0.83</td>\n",
+       "      <td>Partly Cloudy</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2012-04-21 02:00:00</td>\n",
+       "      <td>MAC000768</td>\n",
+       "      <td>0.046</td>\n",
+       "      <td>30min</td>\n",
+       "      <td>32544</td>\n",
+       "      <td>Std</td>\n",
+       "      <td>ACORN-A</td>\n",
+       "      <td>Affluent</td>\n",
+       "      <td>block_1</td>\n",
+       "      <td>NO_HOLIDAY</td>\n",
+       "      <td>...</td>\n",
+       "      <td>246</td>\n",
+       "      <td>5.68</td>\n",
+       "      <td>3.52</td>\n",
+       "      <td>994.820007</td>\n",
+       "      <td>3.15</td>\n",
+       "      <td>3.25</td>\n",
+       "      <td>rain</td>\n",
+       "      <td>clear-night</td>\n",
+       "      <td>0.86</td>\n",
+       "      <td>Clear</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 21 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            timestamp      LCLid  energy_consumption frequency  series_length  \\\n",
+       "0 2012-04-21 00:00:00  MAC000768               0.844     30min          32544   \n",
+       "1 2012-04-21 00:30:00  MAC000768               0.265     30min          32544   \n",
+       "2 2012-04-21 01:00:00  MAC000768               0.262     30min          32544   \n",
+       "3 2012-04-21 01:30:00  MAC000768               0.234     30min          32544   \n",
+       "4 2012-04-21 02:00:00  MAC000768               0.046     30min          32544   \n",
+       "\n",
+       "  stdorToU    Acorn Acorn_grouped     file    holidays  ...  windBearing  \\\n",
+       "0      Std  ACORN-A      Affluent  block_1  NO_HOLIDAY  ...          251   \n",
+       "1      Std  ACORN-A      Affluent  block_1  NO_HOLIDAY  ...          251   \n",
+       "2      Std  ACORN-A      Affluent  block_1  NO_HOLIDAY  ...          251   \n",
+       "3      Std  ACORN-A      Affluent  block_1  NO_HOLIDAY  ...          251   \n",
+       "4      Std  ACORN-A      Affluent  block_1  NO_HOLIDAY  ...          246   \n",
+       "\n",
+       "   temperature  dewPoint    pressure  apparentTemperature  windSpeed  \\\n",
+       "0         6.42      3.54  994.960022                 3.79       3.64   \n",
+       "1         6.42      3.54  994.960022                 3.79       3.64   \n",
+       "2         6.20      3.61  994.979980                 3.67       3.42   \n",
+       "3         6.20      3.61  994.979980                 3.67       3.42   \n",
+       "4         5.68      3.52  994.820007                 3.15       3.25   \n",
+       "\n",
+       "   precipType                 icon humidity        summary  \n",
+       "0        rain  partly-cloudy-night     0.82  Partly Cloudy  \n",
+       "1        rain  partly-cloudy-night     0.82  Partly Cloudy  \n",
+       "2        rain  partly-cloudy-night     0.83  Partly Cloudy  \n",
+       "3        rain  partly-cloudy-night     0.83  Partly Cloudy  \n",
+       "4        rain          clear-night     0.86          Clear  \n",
+       "\n",
+       "[5 rows x 21 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "783e372f-6459-49cc-b2d1-640c6b2b5401",
+   "metadata": {},
+   "source": [
+    "## Running Baseline Forecast for all consumers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "40a6447d-18cc-463b-bc94-82b2f6cbd7d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lcl_ids = sorted(train_df.LCLid.unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38188c7c-a3d1-416c-9670-a4caccfa09c3",
+   "metadata": {},
+   "source": [
+    "Here we are running the forecast one step ahead at a time. If current timestep is $t$, then we train till $t-1$ and predict for $t$. And to predict $t+1$, we train till $t$, and so on.\n",
+    "\n",
+    "Running this kind of backtesting for a two months on half-hourly dataset for 400 households take too long to feasibly compute. So to assess one-step ahead forecast performance in test and validation periods, we have chosen two baselines(Naive and Seasonal Naive) which can easily and quickly be done using pandas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86246ccc-716e-4fe2-aa7d-097c0356093b",
+   "metadata": {},
+   "source": [
+    "### Naive Forecast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "dcc43a7e-db30-410e-9d4b-f4d1c54db353",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#from src.utils.ts_utils import darts_metrics_adapter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "891ff0f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models =  [Naive(), \n",
+    "                SeasonalNaive(season_length=48*7)\n",
+    "                ]\n",
+    "\n",
+    "model_names = [model.__class__.__name__ for model in models]\n",
+    "\n",
+    "sf = StatsForecast(\n",
+    "    models=models,\n",
+    "    freq='30min',\n",
+    "    n_jobs=-1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30279237",
+   "metadata": {},
+   "source": [
+    "Doing a little cleanup and dataprep before modeling. Easiest way to validate our 1-step ahead models is to do a cross validation.  As such, to evaluate the validation data, we will append both the train_df and val_df, and then use cross validation for backtesting. In NIXTLA, this is very easy to do.\n",
+    "\n",
+    "When you do crossvalidation in NIXTLA, you will notice a \"Cutff\" column added.  This represents where the training data was \"cut off\".  In our example below, you will notice the cutoff is 1-step prior to the timestamp, showcasing the 1-step ahead forecast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "076f6aff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tr = train_df[[\"LCLid\",\"timestamp\",\"energy_consumption\"]]\n",
+    "vl = val_df[[\"LCLid\",\"timestamp\",\"energy_consumption\"]]\n",
+    "ts = test_df[[\"LCLid\",\"timestamp\",\"energy_consumption\"]]\n",
+    "\n",
+    "tr_vl = pd.concat([tr, vl]) # Creating the full training + validation dataset for cross validation\n",
+    "tr_vl_ts = pd.concat([tr, vl, ts]) # Creating the full training + validation + test dataset for cross validation\n",
+    "\n",
+    "tr_vl['LCLid'] = tr_vl['LCLid'].astype(str)\n",
+    "tr_vl_ts['LCLid'] = tr_vl_ts['LCLid'].astype(str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "00c1f4f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crossvalidation_val_df = sf.cross_validation(\n",
+    "    df = tr_vl,\n",
+    "    h = 1,\n",
+    "    step_size = 1,\n",
+    "    n_windows = len(vl.timestamp.unique()),\n",
+    "    id_col = 'LCLid',\n",
+    "    time_col = 'timestamp',\n",
+    "    target_col = 'energy_consumption',\n",
+    "\n",
+    "  )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "36ca9873",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crossvalidation_test_df = sf.cross_validation(\n",
+    "    df = tr_vl_ts,\n",
+    "    h = 1,\n",
+    "    step_size = 1,\n",
+    "    n_windows = len(ts.timestamp.unique()),\n",
+    "    id_col = 'LCLid',\n",
+    "    time_col = 'timestamp',\n",
+    "    target_col = 'energy_consumption',\n",
+    "\n",
+    "  )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4159a25b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>cutoff</th>\n",
+       "      <th>y</th>\n",
+       "      <th>Naive</th>\n",
+       "      <th>SeasonalNaive</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>2014-01-01 00:00:00</td>\n",
+       "      <td>2013-12-31 23:30:00</td>\n",
+       "      <td>0.165</td>\n",
+       "      <td>0.179</td>\n",
+       "      <td>0.157</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>2014-01-01 00:30:00</td>\n",
+       "      <td>2014-01-01 00:00:00</td>\n",
+       "      <td>0.167</td>\n",
+       "      <td>0.165</td>\n",
+       "      <td>0.083</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>2014-01-01 01:00:00</td>\n",
+       "      <td>2014-01-01 00:30:00</td>\n",
+       "      <td>0.150</td>\n",
+       "      <td>0.167</td>\n",
+       "      <td>0.054</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       LCLid           timestamp              cutoff      y  Naive  \\\n",
+       "0  MAC000061 2014-01-01 00:00:00 2013-12-31 23:30:00  0.165  0.179   \n",
+       "1  MAC000061 2014-01-01 00:30:00 2014-01-01 00:00:00  0.167  0.165   \n",
+       "2  MAC000061 2014-01-01 01:00:00 2014-01-01 00:30:00  0.150  0.167   \n",
+       "\n",
+       "   SeasonalNaive  \n",
+       "0          0.157  \n",
+       "1          0.083  \n",
+       "2          0.054  "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crossvalidation_val_df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "dea558c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>cutoff</th>\n",
+       "      <th>y</th>\n",
+       "      <th>Naive</th>\n",
+       "      <th>SeasonalNaive</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>2014-02-01 00:00:00</td>\n",
+       "      <td>2014-01-31 23:30:00</td>\n",
+       "      <td>0.066</td>\n",
+       "      <td>0.069</td>\n",
+       "      <td>0.057</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>2014-02-01 00:30:00</td>\n",
+       "      <td>2014-02-01 00:00:00</td>\n",
+       "      <td>0.063</td>\n",
+       "      <td>0.066</td>\n",
+       "      <td>0.058</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>2014-02-01 01:00:00</td>\n",
+       "      <td>2014-02-01 00:30:00</td>\n",
+       "      <td>0.040</td>\n",
+       "      <td>0.063</td>\n",
+       "      <td>0.060</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       LCLid           timestamp              cutoff      y  Naive  \\\n",
+       "0  MAC000061 2014-02-01 00:00:00 2014-01-31 23:30:00  0.066  0.069   \n",
+       "1  MAC000061 2014-02-01 00:30:00 2014-02-01 00:00:00  0.063  0.066   \n",
+       "2  MAC000061 2014-02-01 01:00:00 2014-02-01 00:30:00  0.040  0.063   \n",
+       "\n",
+       "   SeasonalNaive  \n",
+       "0          0.057  \n",
+       "1          0.058  \n",
+       "2          0.060  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "crossvalidation_test_df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "f9ec5838",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>metric</th>\n",
+       "      <th>Naive</th>\n",
+       "      <th>SeasonalNaive</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.003561</td>\n",
+       "      <td>0.008076</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.040691</td>\n",
+       "      <td>0.053449</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.011811</td>\n",
+       "      <td>0.032999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MAC000086</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.048976</td>\n",
+       "      <td>0.047775</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MAC000126</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.022801</td>\n",
+       "      <td>0.051587</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       LCLid metric     Naive  SeasonalNaive\n",
+       "0  MAC000061    mse  0.003561       0.008076\n",
+       "1  MAC000062    mse  0.040691       0.053449\n",
+       "2  MAC000066    mse  0.011811       0.032999\n",
+       "3  MAC000086    mse  0.048976       0.047775\n",
+       "4  MAC000126    mse  0.022801       0.051587"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fcst_mase = partial(mase, seasonality=1)\n",
+    "fcst_mase.__name__ = \"mase\"\n",
+    "forecast_bias_NIXTLA.__name__ = \"forecast_bias\"\n",
+    "\n",
+    "baseline_val_metrics_df = evaluate(\n",
+    "                        df   = crossvalidation_val_df.drop(['cutoff'], axis =1 ), \n",
+    "                        metrics  = [mse, mae, rmse, fcst_mase, forecast_bias_NIXTLA],\n",
+    "                        models  = model_names,\n",
+    "                        train_df  = tr_vl[['timestamp', 'LCLid', 'energy_consumption']].rename(columns = {'energy_consumption':'y'}),\n",
+    "                        id_col = 'LCLid',\n",
+    "                        time_col = 'timestamp',\n",
+    "                        target_col = 'y'\n",
+    "                         )\n",
+    "baseline_val_metrics_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "9cede1dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>metric</th>\n",
+       "      <th>Naive</th>\n",
+       "      <th>SeasonalNaive</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>602</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>forecast_bias</td>\n",
+       "      <td>0.000574</td>\n",
+       "      <td>0.177259</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         LCLid         metric     Naive  SeasonalNaive\n",
+       "602  MAC000066  forecast_bias  0.000574       0.177259"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_val_metrics_df[(baseline_val_metrics_df.LCLid =='MAC000066') & (baseline_val_metrics_df.metric=='forecast_bias')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "320df024",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>metric</th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>Algorithm</th>\n",
+       "      <th>forecast_bias</th>\n",
+       "      <th>mae</th>\n",
+       "      <th>mase</th>\n",
+       "      <th>mse</th>\n",
+       "      <th>rmse</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000591</td>\n",
+       "      <td>0.033290</td>\n",
+       "      <td>0.954536</td>\n",
+       "      <td>0.003561</td>\n",
+       "      <td>0.059672</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.028300</td>\n",
+       "      <td>0.059912</td>\n",
+       "      <td>1.717861</td>\n",
+       "      <td>0.008076</td>\n",
+       "      <td>0.089865</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000767</td>\n",
+       "      <td>0.088534</td>\n",
+       "      <td>1.167550</td>\n",
+       "      <td>0.040691</td>\n",
+       "      <td>0.201719</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>-0.003600</td>\n",
+       "      <td>0.101974</td>\n",
+       "      <td>1.344793</td>\n",
+       "      <td>0.053449</td>\n",
+       "      <td>0.231191</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000574</td>\n",
+       "      <td>0.043099</td>\n",
+       "      <td>1.110772</td>\n",
+       "      <td>0.011811</td>\n",
+       "      <td>0.108680</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.177259</td>\n",
+       "      <td>0.089192</td>\n",
+       "      <td>2.298688</td>\n",
+       "      <td>0.032999</td>\n",
+       "      <td>0.181657</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>MAC000086</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>-0.000085</td>\n",
+       "      <td>0.167172</td>\n",
+       "      <td>1.873062</td>\n",
+       "      <td>0.048976</td>\n",
+       "      <td>0.221305</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>MAC000086</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.022808</td>\n",
+       "      <td>0.155553</td>\n",
+       "      <td>1.742879</td>\n",
+       "      <td>0.047775</td>\n",
+       "      <td>0.218575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>MAC000126</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000710</td>\n",
+       "      <td>0.071154</td>\n",
+       "      <td>1.075346</td>\n",
+       "      <td>0.022801</td>\n",
+       "      <td>0.151001</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>MAC000126</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.022045</td>\n",
+       "      <td>0.120750</td>\n",
+       "      <td>1.824890</td>\n",
+       "      <td>0.051587</td>\n",
+       "      <td>0.227127</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "metric      LCLid      Algorithm  forecast_bias       mae      mase       mse  \\\n",
+       "0       MAC000061          Naive       0.000591  0.033290  0.954536  0.003561   \n",
+       "1       MAC000061  SeasonalNaive       0.028300  0.059912  1.717861  0.008076   \n",
+       "2       MAC000062          Naive       0.000767  0.088534  1.167550  0.040691   \n",
+       "3       MAC000062  SeasonalNaive      -0.003600  0.101974  1.344793  0.053449   \n",
+       "4       MAC000066          Naive       0.000574  0.043099  1.110772  0.011811   \n",
+       "5       MAC000066  SeasonalNaive       0.177259  0.089192  2.298688  0.032999   \n",
+       "6       MAC000086          Naive      -0.000085  0.167172  1.873062  0.048976   \n",
+       "7       MAC000086  SeasonalNaive       0.022808  0.155553  1.742879  0.047775   \n",
+       "8       MAC000126          Naive       0.000710  0.071154  1.075346  0.022801   \n",
+       "9       MAC000126  SeasonalNaive       0.022045  0.120750  1.824890  0.051587   \n",
+       "\n",
+       "metric      rmse  \n",
+       "0       0.059672  \n",
+       "1       0.089865  \n",
+       "2       0.201719  \n",
+       "3       0.231191  \n",
+       "4       0.108680  \n",
+       "5       0.181657  \n",
+       "6       0.221305  \n",
+       "7       0.218575  \n",
+       "8       0.151001  \n",
+       "9       0.227127  "
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_val_metrics_df_pivot = (baseline_val_metrics_df\n",
+    "    .melt(id_vars = ['LCLid','metric'], value_vars = model_names, var_name ='Algorithm', value_name='score')\n",
+    "    .pivot_table(index = ['LCLid','Algorithm'], columns = 'metric', values = 'score', observed = 'True')\n",
+    ").reset_index()\n",
+    "baseline_val_metrics_df_pivot.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "1a62b308",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Naive', 'SeasonalNaive']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[model.__class__.__name__ for model in models]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "86db3ee4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>metric</th>\n",
+       "      <th>Naive</th>\n",
+       "      <th>SeasonalNaive</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.003875</td>\n",
+       "      <td>0.009974</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.038202</td>\n",
+       "      <td>0.062443</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.001024</td>\n",
+       "      <td>0.004306</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MAC000086</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.054223</td>\n",
+       "      <td>0.046820</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MAC000126</td>\n",
+       "      <td>mse</td>\n",
+       "      <td>0.010566</td>\n",
+       "      <td>0.022787</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       LCLid metric     Naive  SeasonalNaive\n",
+       "0  MAC000061    mse  0.003875       0.009974\n",
+       "1  MAC000062    mse  0.038202       0.062443\n",
+       "2  MAC000066    mse  0.001024       0.004306\n",
+       "3  MAC000086    mse  0.054223       0.046820\n",
+       "4  MAC000126    mse  0.010566       0.022787"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_test_metrics_df =  evaluate(\n",
+    "                        df   = crossvalidation_test_df.drop(['cutoff'], axis =1 ), \n",
+    "                        metrics  = [mse, mae, rmse, fcst_mase, forecast_bias_NIXTLA],\n",
+    "                        models  = model_names,\n",
+    "                        train_df  = tr_vl[['timestamp', 'LCLid', 'energy_consumption']].rename(columns = {'energy_consumption':'y'}),\n",
+    "                        id_col = 'LCLid',\n",
+    "                        time_col = 'timestamp',\n",
+    "                        target_col = 'y'\n",
+    "                         )\n",
+    "baseline_test_metrics_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "029efc6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>metric</th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>Algorithm</th>\n",
+       "      <th>forecast_bias</th>\n",
+       "      <th>mae</th>\n",
+       "      <th>mase</th>\n",
+       "      <th>mse</th>\n",
+       "      <th>rmse</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>-0.000545</td>\n",
+       "      <td>0.036842</td>\n",
+       "      <td>1.056369</td>\n",
+       "      <td>0.003875</td>\n",
+       "      <td>0.062247</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>-0.036513</td>\n",
+       "      <td>0.069009</td>\n",
+       "      <td>1.978709</td>\n",
+       "      <td>0.009974</td>\n",
+       "      <td>0.099869</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000032</td>\n",
+       "      <td>0.089600</td>\n",
+       "      <td>1.181598</td>\n",
+       "      <td>0.038202</td>\n",
+       "      <td>0.195454</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.029383</td>\n",
+       "      <td>0.109424</td>\n",
+       "      <td>1.443039</td>\n",
+       "      <td>0.062443</td>\n",
+       "      <td>0.249886</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>-0.001415</td>\n",
+       "      <td>0.006462</td>\n",
+       "      <td>0.166546</td>\n",
+       "      <td>0.001024</td>\n",
+       "      <td>0.031992</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>-0.304294</td>\n",
+       "      <td>0.026859</td>\n",
+       "      <td>0.692213</td>\n",
+       "      <td>0.004306</td>\n",
+       "      <td>0.065620</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>MAC000086</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000100</td>\n",
+       "      <td>0.174187</td>\n",
+       "      <td>1.951657</td>\n",
+       "      <td>0.054223</td>\n",
+       "      <td>0.232859</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>MAC000086</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>-0.022288</td>\n",
+       "      <td>0.151837</td>\n",
+       "      <td>1.701244</td>\n",
+       "      <td>0.046820</td>\n",
+       "      <td>0.216378</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>MAC000126</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000132</td>\n",
+       "      <td>0.055279</td>\n",
+       "      <td>0.835422</td>\n",
+       "      <td>0.010566</td>\n",
+       "      <td>0.102791</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>MAC000126</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.054904</td>\n",
+       "      <td>0.086149</td>\n",
+       "      <td>1.301965</td>\n",
+       "      <td>0.022787</td>\n",
+       "      <td>0.150955</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "metric      LCLid      Algorithm  forecast_bias       mae      mase       mse  \\\n",
+       "0       MAC000061          Naive      -0.000545  0.036842  1.056369  0.003875   \n",
+       "1       MAC000061  SeasonalNaive      -0.036513  0.069009  1.978709  0.009974   \n",
+       "2       MAC000062          Naive       0.000032  0.089600  1.181598  0.038202   \n",
+       "3       MAC000062  SeasonalNaive       0.029383  0.109424  1.443039  0.062443   \n",
+       "4       MAC000066          Naive      -0.001415  0.006462  0.166546  0.001024   \n",
+       "5       MAC000066  SeasonalNaive      -0.304294  0.026859  0.692213  0.004306   \n",
+       "6       MAC000086          Naive       0.000100  0.174187  1.951657  0.054223   \n",
+       "7       MAC000086  SeasonalNaive      -0.022288  0.151837  1.701244  0.046820   \n",
+       "8       MAC000126          Naive       0.000132  0.055279  0.835422  0.010566   \n",
+       "9       MAC000126  SeasonalNaive       0.054904  0.086149  1.301965  0.022787   \n",
+       "\n",
+       "metric      rmse  \n",
+       "0       0.062247  \n",
+       "1       0.099869  \n",
+       "2       0.195454  \n",
+       "3       0.249886  \n",
+       "4       0.031992  \n",
+       "5       0.065620  \n",
+       "6       0.232859  \n",
+       "7       0.216378  \n",
+       "8       0.102791  \n",
+       "9       0.150955  "
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_test_metrics_df_pivot = (baseline_test_metrics_df\n",
+    "    .melt(id_vars = ['LCLid','metric'], value_vars = model_names, var_name ='Algorithm', value_name='score')\n",
+    "    .pivot_table(index = ['LCLid','Algorithm'], columns = 'metric', values = 'score', observed = 'True')\n",
+    ").reset_index()\n",
+    "baseline_test_metrics_df_pivot.head(10)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b48dd864",
+   "metadata": {},
+   "source": [
+    "# Overall Metrics\n",
+    "\n",
+    "For the overall metrics, we can use the same accuracy function used above, but remove the aggregation by LCLid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32b18f2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils import ts_utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "adedafd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'MAE': 0.0881616,\n",
+       " 'MSE': 0.04498119,\n",
+       " 'meanMASE': 1.0899727,\n",
+       " 'Forecast Bias': -0.0029618898391831935}"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "overall_metrics_naive_val = {\n",
+    "    \"MAE\": ts_utils.mae(crossvalidation_val_df[\"y\"], crossvalidation_val_df[\"Naive\"]),\n",
+    "    \"MSE\": ts_utils.mse(crossvalidation_val_df[\"y\"], crossvalidation_val_df[\"Naive\"]),\n",
+    "    \"meanMASE\": baseline_val_metrics_df[baseline_val_metrics_df.metric =='mase'][\"Naive\"].mean(),\n",
+    "    \"Forecast Bias\": ts_utils.forecast_bias_aggregate(crossvalidation_val_df[\"y\"], crossvalidation_val_df[\"Naive\"])\n",
+    "}\n",
+    "\n",
+    "overall_metrics_naive_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "bb747d33",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'MAE': 0.12919722,\n",
+       " 'MSE': 0.077654414,\n",
+       " 'meanMASE': 1.5819468,\n",
+       " 'Forecast Bias': -1.0015331232898155}"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "overall_metrics_snaive_val = {\n",
+    "    \"MAE\": ts_utils.mae(crossvalidation_val_df[\"y\"], crossvalidation_val_df[\"SeasonalNaive\"]),\n",
+    "    \"MSE\": ts_utils.mse(crossvalidation_val_df[\"y\"], crossvalidation_val_df[\"SeasonalNaive\"]),\n",
+    "    \"meanMASE\": baseline_val_metrics_df[baseline_val_metrics_df.metric =='mase'][\"SeasonalNaive\"].mean(),\n",
+    "    \"Forecast Bias\": ts_utils.forecast_bias_aggregate(crossvalidation_val_df[\"y\"], crossvalidation_val_df[\"SeasonalNaive\"])\n",
+    "}\n",
+    "overall_metrics_snaive_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "d6e11310",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'MAE': 0.08566107,\n",
+       " 'MSE': 0.044766486,\n",
+       " 'meanMASE': 1.0499331,\n",
+       " 'Forecast Bias': 0.017577425433739073}"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "overall_metrics_naive_test = {\n",
+    "    \"MAE\": ts_utils.mae(crossvalidation_test_df[\"y\"], crossvalidation_test_df[\"Naive\"]),\n",
+    "    \"MSE\": ts_utils.mse(crossvalidation_test_df[\"y\"], crossvalidation_test_df[\"Naive\"]),\n",
+    "    \"meanMASE\": baseline_test_metrics_df[baseline_test_metrics_df.metric =='mase'][\"Naive\"].mean(),\n",
+    "    \"Forecast Bias\": ts_utils.forecast_bias_aggregate(crossvalidation_test_df[\"y\"], crossvalidation_test_df[\"Naive\"])\n",
+    "}\n",
+    "\n",
+    "overall_metrics_naive_test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "beec3538",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'MAE': 0.12169953,\n",
+       " 'MSE': 0.07150105,\n",
+       " 'meanMASE': 1.4867879,\n",
+       " 'Forecast Bias': 4.066730574245776}"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "overall_metrics_snaive_test = {\n",
+    "    \"MAE\": ts_utils.mae(crossvalidation_test_df[\"y\"], crossvalidation_test_df[\"SeasonalNaive\"]),\n",
+    "    \"MSE\": ts_utils.mse(crossvalidation_test_df[\"y\"], crossvalidation_test_df[\"SeasonalNaive\"]),\n",
+    "    \"meanMASE\": baseline_test_metrics_df[baseline_test_metrics_df.metric =='mase'][\"SeasonalNaive\"].mean(),\n",
+    "    \"Forecast Bias\": ts_utils.forecast_bias_aggregate(crossvalidation_test_df[\"y\"], crossvalidation_test_df[\"SeasonalNaive\"])\n",
+    "}\n",
+    "overall_metrics_snaive_test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5e51169-e983-44f0-97b0-c39d988ce549",
+   "metadata": {},
+   "source": [
+    "## Evaluation of Baseline Forecast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "b4c5888e-c587-44e1-916f-cb10eae833d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_76761_row0_col0, #T_76761_row0_col1, #T_76761_row0_col2, #T_76761_row1_col3 {\n",
+       "  background-color: lightgreen;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_76761\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_76761_level0_col0\" class=\"col_heading level0 col0\" >MAE</th>\n",
+       "      <th id=\"T_76761_level0_col1\" class=\"col_heading level0 col1\" >MSE</th>\n",
+       "      <th id=\"T_76761_level0_col2\" class=\"col_heading level0 col2\" >meanMASE</th>\n",
+       "      <th id=\"T_76761_level0_col3\" class=\"col_heading level0 col3\" >Forecast Bias</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_76761_level0_row0\" class=\"row_heading level0 row0\" >Naive</th>\n",
+       "      <td id=\"T_76761_row0_col0\" class=\"data row0 col0\" >0.088</td>\n",
+       "      <td id=\"T_76761_row0_col1\" class=\"data row0 col1\" >0.045</td>\n",
+       "      <td id=\"T_76761_row0_col2\" class=\"data row0 col2\" >1.090</td>\n",
+       "      <td id=\"T_76761_row0_col3\" class=\"data row0 col3\" >-0.00%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_76761_level0_row1\" class=\"row_heading level0 row1\" >Seasonal Naive</th>\n",
+       "      <td id=\"T_76761_row1_col0\" class=\"data row1 col0\" >0.129</td>\n",
+       "      <td id=\"T_76761_row1_col1\" class=\"data row1 col1\" >0.078</td>\n",
+       "      <td id=\"T_76761_row1_col2\" class=\"data row1 col2\" >1.582</td>\n",
+       "      <td id=\"T_76761_row1_col3\" class=\"data row1 col3\" >-1.00%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x1e341ff2010>"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agg_metric_val_df = pd.DataFrame([overall_metrics_naive_val, overall_metrics_snaive_val], index=[\"Naive\",\"Seasonal Naive\"])\n",
+    "\n",
+    "agg_metric_val_df.style.format({\"MAE\": \"{:.3f}\", \n",
+    "                          \"MSE\": \"{:.3f}\", \n",
+    "                          \"meanMASE\": \"{:.3f}\", \n",
+    "                          \"Forecast Bias\": \"{:.2f}%\"}).highlight_min(color='lightgreen')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "bf160ae1-cfff-4285-8121-ab043947d421",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "#T_a4369_row0_col0, #T_a4369_row0_col1, #T_a4369_row0_col2, #T_a4369_row0_col3 {\n",
+       "  background-color: lightgreen;\n",
+       "}\n",
+       "</style>\n",
+       "<table id=\"T_a4369\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_a4369_level0_col0\" class=\"col_heading level0 col0\" >MAE</th>\n",
+       "      <th id=\"T_a4369_level0_col1\" class=\"col_heading level0 col1\" >MSE</th>\n",
+       "      <th id=\"T_a4369_level0_col2\" class=\"col_heading level0 col2\" >meanMASE</th>\n",
+       "      <th id=\"T_a4369_level0_col3\" class=\"col_heading level0 col3\" >Forecast Bias</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a4369_level0_row0\" class=\"row_heading level0 row0\" >Naive</th>\n",
+       "      <td id=\"T_a4369_row0_col0\" class=\"data row0 col0\" >0.086</td>\n",
+       "      <td id=\"T_a4369_row0_col1\" class=\"data row0 col1\" >0.045</td>\n",
+       "      <td id=\"T_a4369_row0_col2\" class=\"data row0 col2\" >1.050</td>\n",
+       "      <td id=\"T_a4369_row0_col3\" class=\"data row0 col3\" >0.02%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_a4369_level0_row1\" class=\"row_heading level0 row1\" >Seasonal Naive</th>\n",
+       "      <td id=\"T_a4369_row1_col0\" class=\"data row1 col0\" >0.122</td>\n",
+       "      <td id=\"T_a4369_row1_col1\" class=\"data row1 col1\" >0.072</td>\n",
+       "      <td id=\"T_a4369_row1_col2\" class=\"data row1 col2\" >1.487</td>\n",
+       "      <td id=\"T_a4369_row1_col3\" class=\"data row1 col3\" >4.07%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x1e3429b0650>"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agg_metric_test_df = pd.DataFrame([overall_metrics_naive_test, overall_metrics_snaive_test], index=[\"Naive\",\"Seasonal Naive\"])\n",
+    "\n",
+    "agg_metric_test_df.style.format({\"MAE\": \"{:.3f}\", \n",
+    "                          \"MSE\": \"{:.3f}\", \n",
+    "                          \"meanMASE\": \"{:.3f}\", \n",
+    "                          \"Forecast Bias\": \"{:.2f}%\"}).highlight_min(color='lightgreen')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "f95af803",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>metric</th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>Algorithm</th>\n",
+       "      <th>forecast_bias</th>\n",
+       "      <th>mae</th>\n",
+       "      <th>mase</th>\n",
+       "      <th>mse</th>\n",
+       "      <th>rmse</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000591</td>\n",
+       "      <td>0.033290</td>\n",
+       "      <td>0.954536</td>\n",
+       "      <td>0.003561</td>\n",
+       "      <td>0.059672</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.028300</td>\n",
+       "      <td>0.059912</td>\n",
+       "      <td>1.717861</td>\n",
+       "      <td>0.008076</td>\n",
+       "      <td>0.089865</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000767</td>\n",
+       "      <td>0.088534</td>\n",
+       "      <td>1.167550</td>\n",
+       "      <td>0.040691</td>\n",
+       "      <td>0.201719</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>-0.003600</td>\n",
+       "      <td>0.101974</td>\n",
+       "      <td>1.344793</td>\n",
+       "      <td>0.053449</td>\n",
+       "      <td>0.231191</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000574</td>\n",
+       "      <td>0.043099</td>\n",
+       "      <td>1.110772</td>\n",
+       "      <td>0.011811</td>\n",
+       "      <td>0.108680</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>295</th>\n",
+       "      <td>MAC005463</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.003513</td>\n",
+       "      <td>0.095401</td>\n",
+       "      <td>1.675904</td>\n",
+       "      <td>0.028323</td>\n",
+       "      <td>0.168296</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>296</th>\n",
+       "      <td>MAC005521</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000771</td>\n",
+       "      <td>0.193729</td>\n",
+       "      <td>1.465386</td>\n",
+       "      <td>0.261627</td>\n",
+       "      <td>0.511495</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>297</th>\n",
+       "      <td>MAC005521</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.067720</td>\n",
+       "      <td>0.220915</td>\n",
+       "      <td>1.671020</td>\n",
+       "      <td>0.290943</td>\n",
+       "      <td>0.539391</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>298</th>\n",
+       "      <td>MAC005529</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000047</td>\n",
+       "      <td>0.053521</td>\n",
+       "      <td>0.992287</td>\n",
+       "      <td>0.019193</td>\n",
+       "      <td>0.138538</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>299</th>\n",
+       "      <td>MAC005529</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.004557</td>\n",
+       "      <td>0.110623</td>\n",
+       "      <td>2.050953</td>\n",
+       "      <td>0.051093</td>\n",
+       "      <td>0.226038</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>300 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "metric      LCLid      Algorithm  forecast_bias       mae      mase       mse  \\\n",
+       "0       MAC000061          Naive       0.000591  0.033290  0.954536  0.003561   \n",
+       "1       MAC000061  SeasonalNaive       0.028300  0.059912  1.717861  0.008076   \n",
+       "2       MAC000062          Naive       0.000767  0.088534  1.167550  0.040691   \n",
+       "3       MAC000062  SeasonalNaive      -0.003600  0.101974  1.344793  0.053449   \n",
+       "4       MAC000066          Naive       0.000574  0.043099  1.110772  0.011811   \n",
+       "..            ...            ...            ...       ...       ...       ...   \n",
+       "295     MAC005463  SeasonalNaive       0.003513  0.095401  1.675904  0.028323   \n",
+       "296     MAC005521          Naive       0.000771  0.193729  1.465386  0.261627   \n",
+       "297     MAC005521  SeasonalNaive       0.067720  0.220915  1.671020  0.290943   \n",
+       "298     MAC005529          Naive       0.000047  0.053521  0.992287  0.019193   \n",
+       "299     MAC005529  SeasonalNaive       0.004557  0.110623  2.050953  0.051093   \n",
+       "\n",
+       "metric      rmse  \n",
+       "0       0.059672  \n",
+       "1       0.089865  \n",
+       "2       0.201719  \n",
+       "3       0.231191  \n",
+       "4       0.108680  \n",
+       "..           ...  \n",
+       "295     0.168296  \n",
+       "296     0.511495  \n",
+       "297     0.539391  \n",
+       "298     0.138538  \n",
+       "299     0.226038  \n",
+       "\n",
+       "[300 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_val_metrics_df_pivot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "617e450b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>mase=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 500,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.9545364,
+          1.1675498,
+          1.1107723,
+          1.8730619,
+          1.0753459,
+          0.2422139,
+          1.1153513,
+          1.333517,
+          1.3463339,
+          0.7280462,
+          1.1003426,
+          0.9442139,
+          1.0125275,
+          1.6579833,
+          1.1207129,
+          1.2451624,
+          1.2536958,
+          1.2041852,
+          0.8960695,
+          1.089632,
+          1.2029351,
+          1.196707,
+          1.0792257,
+          1.421866,
+          1.0264736,
+          0.96855146,
+          1.0524575,
+          1.0685477,
+          1.2031221,
+          1.0909251,
+          1.0378627,
+          0.83783585,
+          1.0223984,
+          0.9406674,
+          1.0300157,
+          0.45142734,
+          0.9349843,
+          0.23741533,
+          1.2503281,
+          0.88226765,
+          1.1562308,
+          1.0941956,
+          0.8976069,
+          1.2561052,
+          0.8725332,
+          1.3067744,
+          1.2291069,
+          0.88786197,
+          1.0151113,
+          0.7711155,
+          1.5434362,
+          1.1089493,
+          1.1562468,
+          1.1792966,
+          0.44387168,
+          3.6085954,
+          0.920296,
+          1.0933285,
+          1.1675931,
+          1.2445877,
+          0.85095376,
+          1.0335746,
+          1.6616958,
+          1.3642268,
+          1.2046181,
+          1.18159,
+          0.9345297,
+          0.8412642,
+          0.96654683,
+          1.2506766,
+          1.0380899,
+          1.0657451,
+          0.658576,
+          0.79705286,
+          1.0465604,
+          0.71534353,
+          1.1319448,
+          1.0315267,
+          1.0840219,
+          0.1894001,
+          1.0651642,
+          1.0086465,
+          1.2106744,
+          1.4126581,
+          1.3572222,
+          0.98492223,
+          1.1889073,
+          0.9555705,
+          0.98215896,
+          1.0647233,
+          1.2249256,
+          1.0675843,
+          0.9548096,
+          1.0026025,
+          1.0821016,
+          1.1748441,
+          0.98976415,
+          0.89005864,
+          1.37145,
+          1.303495,
+          1.0824625,
+          0.97486204,
+          1.2535477,
+          1.0465027,
+          1.2365463,
+          1.2187086,
+          0.92063856,
+          1.0884825,
+          1.0593088,
+          1.336269,
+          1.205904,
+          0.8598521,
+          1.2586836,
+          1.2550156,
+          0.8486282,
+          1.2275668,
+          1.0758961,
+          1.25403,
+          1.1422465,
+          0.7569439,
+          0.18806545,
+          1.1382545,
+          1.1897486,
+          1.4531235,
+          0.89737767,
+          1.0347084,
+          1.0560231,
+          0.8667355,
+          1.215799,
+          1.2208704,
+          0.98917246,
+          1.1287642,
+          1.2944597,
+          0.9700585,
+          1.0311822,
+          1.0148284,
+          0.9887307,
+          1.0640267,
+          1.3548882,
+          1.0029154,
+          0.96390885,
+          1.4008014,
+          1.0369076,
+          0.93959266,
+          1.0413493,
+          1.5084846,
+          1.0944401,
+          1.1506088,
+          1.4653862,
+          0.9922868
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>mase=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.9545364,
+          1.1675498,
+          1.1107723,
+          1.8730619,
+          1.0753459,
+          0.2422139,
+          1.1153513,
+          1.333517,
+          1.3463339,
+          0.7280462,
+          1.1003426,
+          0.9442139,
+          1.0125275,
+          1.6579833,
+          1.1207129,
+          1.2451624,
+          1.2536958,
+          1.2041852,
+          0.8960695,
+          1.089632,
+          1.2029351,
+          1.196707,
+          1.0792257,
+          1.421866,
+          1.0264736,
+          0.96855146,
+          1.0524575,
+          1.0685477,
+          1.2031221,
+          1.0909251,
+          1.0378627,
+          0.83783585,
+          1.0223984,
+          0.9406674,
+          1.0300157,
+          0.45142734,
+          0.9349843,
+          0.23741533,
+          1.2503281,
+          0.88226765,
+          1.1562308,
+          1.0941956,
+          0.8976069,
+          1.2561052,
+          0.8725332,
+          1.3067744,
+          1.2291069,
+          0.88786197,
+          1.0151113,
+          0.7711155,
+          1.5434362,
+          1.1089493,
+          1.1562468,
+          1.1792966,
+          0.44387168,
+          3.6085954,
+          0.920296,
+          1.0933285,
+          1.1675931,
+          1.2445877,
+          0.85095376,
+          1.0335746,
+          1.6616958,
+          1.3642268,
+          1.2046181,
+          1.18159,
+          0.9345297,
+          0.8412642,
+          0.96654683,
+          1.2506766,
+          1.0380899,
+          1.0657451,
+          0.658576,
+          0.79705286,
+          1.0465604,
+          0.71534353,
+          1.1319448,
+          1.0315267,
+          1.0840219,
+          0.1894001,
+          1.0651642,
+          1.0086465,
+          1.2106744,
+          1.4126581,
+          1.3572222,
+          0.98492223,
+          1.1889073,
+          0.9555705,
+          0.98215896,
+          1.0647233,
+          1.2249256,
+          1.0675843,
+          0.9548096,
+          1.0026025,
+          1.0821016,
+          1.1748441,
+          0.98976415,
+          0.89005864,
+          1.37145,
+          1.303495,
+          1.0824625,
+          0.97486204,
+          1.2535477,
+          1.0465027,
+          1.2365463,
+          1.2187086,
+          0.92063856,
+          1.0884825,
+          1.0593088,
+          1.336269,
+          1.205904,
+          0.8598521,
+          1.2586836,
+          1.2550156,
+          0.8486282,
+          1.2275668,
+          1.0758961,
+          1.25403,
+          1.1422465,
+          0.7569439,
+          0.18806545,
+          1.1382545,
+          1.1897486,
+          1.4531235,
+          0.89737767,
+          1.0347084,
+          1.0560231,
+          0.8667355,
+          1.215799,
+          1.2208704,
+          0.98917246,
+          1.1287642,
+          1.2944597,
+          0.9700585,
+          1.0311822,
+          1.0148284,
+          0.9887307,
+          1.0640267,
+          1.3548882,
+          1.0029154,
+          0.96390885,
+          1.4008014,
+          1.0369076,
+          0.93959266,
+          1.0413493,
+          1.5084846,
+          1.0944401,
+          1.1506088,
+          1.4653862,
+          0.9922868
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>mase=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "SeasonalNaive",
+         "nbinsx": 500,
+         "offsetgroup": "SeasonalNaive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          1.717861,
+          1.344793,
+          2.2986884,
+          1.7428786,
+          1.8248897,
+          0,
+          1.3032305,
+          1.6867911,
+          1.8249373,
+          0.8524894,
+          1.8978688,
+          0.9823418,
+          1.2875233,
+          3.4744747,
+          1.3632382,
+          1.304295,
+          1.7831671,
+          1.7401992,
+          1.2314576,
+          1.2180221,
+          1.2317815,
+          1.4812367,
+          1.8746603,
+          2.6326046,
+          1.4555157,
+          1.1444011,
+          1.488677,
+          1.4508147,
+          1.9086899,
+          1.7657795,
+          2.1497378,
+          0.96897906,
+          1.310002,
+          2.0235374,
+          1.471452,
+          0,
+          0.7900654,
+          0,
+          1.7126218,
+          1.1089288,
+          1.7333443,
+          1.7399347,
+          1.2377114,
+          1.8779919,
+          1.2325006,
+          1.6889493,
+          2.3304079,
+          0.94615114,
+          1.1080784,
+          1.0437944,
+          1.7341108,
+          1.1257577,
+          1.3083084,
+          1.4142923,
+          0,
+          6.259469,
+          1.2084367,
+          0.72295064,
+          1.4012665,
+          2.3000133,
+          1.1643219,
+          1.546286,
+          2.587713,
+          2.1697557,
+          1.686109,
+          2.3744848,
+          1.8212507,
+          0.88126254,
+          1.6373471,
+          1.8188599,
+          1.8335192,
+          1.4842185,
+          1.2543138,
+          1.2882104,
+          1.2801285,
+          0.85068166,
+          1.4510263,
+          1.4686246,
+          1.0128837,
+          0,
+          1.2164032,
+          1.2154791,
+          2.162653,
+          1.8072569,
+          1.9192961,
+          1.5018777,
+          2.0587525,
+          1.4102013,
+          1.4611557,
+          1.000576,
+          2.7769449,
+          1.7569578,
+          1.4559746,
+          1.688614,
+          1.466844,
+          2.08271,
+          1.3822935,
+          1.1337656,
+          2.7125435,
+          1.4070626,
+          1.716202,
+          1.22092,
+          1.2431285,
+          1.3858676,
+          1.9769793,
+          1.5798703,
+          1.9678353,
+          1.5465366,
+          1.7118015,
+          2.030905,
+          1.5461607,
+          1.0243354,
+          4.503004,
+          2.0424304,
+          1.0125191,
+          1.3098614,
+          1.1312277,
+          2.6394727,
+          1.8349099,
+          1.2294589,
+          0.60353,
+          1.1474551,
+          1.5890338,
+          2.823292,
+          1.7822696,
+          1.2836803,
+          1.5676075,
+          1.1245782,
+          1.4579812,
+          1.5164473,
+          1.0642481,
+          2.0215206,
+          0.844044,
+          1.2348868,
+          1.9402398,
+          1.7412294,
+          1.1935999,
+          1.2946448,
+          3.4144633,
+          1.1481882,
+          0.82148486,
+          2.4290087,
+          1.3736393,
+          1.4325345,
+          1.1870703,
+          1.0509994,
+          3.6625805,
+          1.6759042,
+          1.6710197,
+          2.0509531
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>mase=%{x}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "SeasonalNaive",
+         "notched": true,
+         "offsetgroup": "SeasonalNaive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          1.717861,
+          1.344793,
+          2.2986884,
+          1.7428786,
+          1.8248897,
+          0,
+          1.3032305,
+          1.6867911,
+          1.8249373,
+          0.8524894,
+          1.8978688,
+          0.9823418,
+          1.2875233,
+          3.4744747,
+          1.3632382,
+          1.304295,
+          1.7831671,
+          1.7401992,
+          1.2314576,
+          1.2180221,
+          1.2317815,
+          1.4812367,
+          1.8746603,
+          2.6326046,
+          1.4555157,
+          1.1444011,
+          1.488677,
+          1.4508147,
+          1.9086899,
+          1.7657795,
+          2.1497378,
+          0.96897906,
+          1.310002,
+          2.0235374,
+          1.471452,
+          0,
+          0.7900654,
+          0,
+          1.7126218,
+          1.1089288,
+          1.7333443,
+          1.7399347,
+          1.2377114,
+          1.8779919,
+          1.2325006,
+          1.6889493,
+          2.3304079,
+          0.94615114,
+          1.1080784,
+          1.0437944,
+          1.7341108,
+          1.1257577,
+          1.3083084,
+          1.4142923,
+          0,
+          6.259469,
+          1.2084367,
+          0.72295064,
+          1.4012665,
+          2.3000133,
+          1.1643219,
+          1.546286,
+          2.587713,
+          2.1697557,
+          1.686109,
+          2.3744848,
+          1.8212507,
+          0.88126254,
+          1.6373471,
+          1.8188599,
+          1.8335192,
+          1.4842185,
+          1.2543138,
+          1.2882104,
+          1.2801285,
+          0.85068166,
+          1.4510263,
+          1.4686246,
+          1.0128837,
+          0,
+          1.2164032,
+          1.2154791,
+          2.162653,
+          1.8072569,
+          1.9192961,
+          1.5018777,
+          2.0587525,
+          1.4102013,
+          1.4611557,
+          1.000576,
+          2.7769449,
+          1.7569578,
+          1.4559746,
+          1.688614,
+          1.466844,
+          2.08271,
+          1.3822935,
+          1.1337656,
+          2.7125435,
+          1.4070626,
+          1.716202,
+          1.22092,
+          1.2431285,
+          1.3858676,
+          1.9769793,
+          1.5798703,
+          1.9678353,
+          1.5465366,
+          1.7118015,
+          2.030905,
+          1.5461607,
+          1.0243354,
+          4.503004,
+          2.0424304,
+          1.0125191,
+          1.3098614,
+          1.1312277,
+          2.6394727,
+          1.8349099,
+          1.2294589,
+          0.60353,
+          1.1474551,
+          1.5890338,
+          2.823292,
+          1.7822696,
+          1.2836803,
+          1.5676075,
+          1.1245782,
+          1.4579812,
+          1.5164473,
+          1.0642481,
+          2.0215206,
+          0.844044,
+          1.2348868,
+          1.9402398,
+          1.7412294,
+          1.1935999,
+          1.2946448,
+          3.4144633,
+          1.1481882,
+          0.82148486,
+          2.4290087,
+          1.3736393,
+          1.4325345,
+          1.1870703,
+          1.0509994,
+          3.6625805,
+          1.6759042,
+          1.6710197,
+          2.0509531
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of MASE in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0,
+          3.2
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "MASE"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_val_metrics_df_pivot, \n",
+    "                   x=\"mase\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=500, \n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"MASE\", ylabel=\"Probability Density\", title=\"Distribution of MASE in the dataset\")\n",
+    "fig.update_layout(xaxis_range=[0,3.2])\n",
+    "# fig.write_image(\"imgs/chapter_4/mase_dist.png\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "7acec1ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>mae=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 100,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.033290323,
+          0.08853427,
+          0.04309946,
+          0.16717204,
+          0.071153894,
+          0.0103765875,
+          0.06475134,
+          0.107366934,
+          0.17533334,
+          0.07586291,
+          0.13127688,
+          0.03644758,
+          0.057661965,
+          0.30372447,
+          0.06564449,
+          0.038350135,
+          0.19317675,
+          0.07056584,
+          0.041061945,
+          0.12753047,
+          0.026020559,
+          0.04761895,
+          0.10135468,
+          0.06992913,
+          0.13516533,
+          0.06232594,
+          0.059567876,
+          0.07859879,
+          0.03017213,
+          0.09214785,
+          0.15946624,
+          0.024200434,
+          0.016753918,
+          0.06682997,
+          0.078098066,
+          0.026923746,
+          0.020007929,
+          0.018634848,
+          0.10263373,
+          0.07194758,
+          0.082987905,
+          0.06866227,
+          0.067594096,
+          0.10487097,
+          0.081709675,
+          0.094605505,
+          0.12545647,
+          0.077572584,
+          0.07016666,
+          0.04884375,
+          0.051352825,
+          0.05737433,
+          0.060917336,
+          0.1165457,
+          0.0008696718,
+          0.18818213,
+          0.077068225,
+          0.06412903,
+          0.09125726,
+          0.16611424,
+          0.041811157,
+          0.032787476,
+          0.068385415,
+          0.13733293,
+          0.10512231,
+          0.049942207,
+          0.24448386,
+          0.027583374,
+          0.06332056,
+          0.058153898,
+          0.06365672,
+          0.0947379,
+          0.06556653,
+          0.07214441,
+          0.07447245,
+          0.039787635,
+          0.07396842,
+          0.06394882,
+          0.051794093,
+          0.008010093,
+          0.07840457,
+          0.04275546,
+          0.14804637,
+          0.012508036,
+          0.061897997,
+          0.077420704,
+          0.12153159,
+          0.05896371,
+          0.11411694,
+          0.0801718,
+          0.06955612,
+          0.13190725,
+          0.03516024,
+          0.093844086,
+          0.11611156,
+          0.11873723,
+          0.050316535,
+          0.043671373,
+          0.13875404,
+          0.07004301,
+          0.03929906,
+          0.05907428,
+          0.019521592,
+          0.076796375,
+          0.18161762,
+          0.17646505,
+          0.09332594,
+          0.19153965,
+          0.10807594,
+          0.15079167,
+          0.042343415,
+          0.1396087,
+          0.048243962,
+          0.12873387,
+          0.0380625,
+          0.109947264,
+          0.08717339,
+          0.19043683,
+          0.1692448,
+          0.04412567,
+          0.023771506,
+          0.22656049,
+          0.03954906,
+          0.05286895,
+          0.02503998,
+          0.14083056,
+          0.09264853,
+          0.054106858,
+          0.088258065,
+          0.065104835,
+          0.07398925,
+          0.13041331,
+          0.35306185,
+          0.058637097,
+          0.15837635,
+          0.07660753,
+          0.0791418,
+          0.16538374,
+          0.03179902,
+          0.04344019,
+          0.05092742,
+          0.2874973,
+          0.24587232,
+          0.030950941,
+          0.036038306,
+          0.13807392,
+          0.060127016,
+          0.06549866,
+          0.19372918,
+          0.053521346
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>mae=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.033290323,
+          0.08853427,
+          0.04309946,
+          0.16717204,
+          0.071153894,
+          0.0103765875,
+          0.06475134,
+          0.107366934,
+          0.17533334,
+          0.07586291,
+          0.13127688,
+          0.03644758,
+          0.057661965,
+          0.30372447,
+          0.06564449,
+          0.038350135,
+          0.19317675,
+          0.07056584,
+          0.041061945,
+          0.12753047,
+          0.026020559,
+          0.04761895,
+          0.10135468,
+          0.06992913,
+          0.13516533,
+          0.06232594,
+          0.059567876,
+          0.07859879,
+          0.03017213,
+          0.09214785,
+          0.15946624,
+          0.024200434,
+          0.016753918,
+          0.06682997,
+          0.078098066,
+          0.026923746,
+          0.020007929,
+          0.018634848,
+          0.10263373,
+          0.07194758,
+          0.082987905,
+          0.06866227,
+          0.067594096,
+          0.10487097,
+          0.081709675,
+          0.094605505,
+          0.12545647,
+          0.077572584,
+          0.07016666,
+          0.04884375,
+          0.051352825,
+          0.05737433,
+          0.060917336,
+          0.1165457,
+          0.0008696718,
+          0.18818213,
+          0.077068225,
+          0.06412903,
+          0.09125726,
+          0.16611424,
+          0.041811157,
+          0.032787476,
+          0.068385415,
+          0.13733293,
+          0.10512231,
+          0.049942207,
+          0.24448386,
+          0.027583374,
+          0.06332056,
+          0.058153898,
+          0.06365672,
+          0.0947379,
+          0.06556653,
+          0.07214441,
+          0.07447245,
+          0.039787635,
+          0.07396842,
+          0.06394882,
+          0.051794093,
+          0.008010093,
+          0.07840457,
+          0.04275546,
+          0.14804637,
+          0.012508036,
+          0.061897997,
+          0.077420704,
+          0.12153159,
+          0.05896371,
+          0.11411694,
+          0.0801718,
+          0.06955612,
+          0.13190725,
+          0.03516024,
+          0.093844086,
+          0.11611156,
+          0.11873723,
+          0.050316535,
+          0.043671373,
+          0.13875404,
+          0.07004301,
+          0.03929906,
+          0.05907428,
+          0.019521592,
+          0.076796375,
+          0.18161762,
+          0.17646505,
+          0.09332594,
+          0.19153965,
+          0.10807594,
+          0.15079167,
+          0.042343415,
+          0.1396087,
+          0.048243962,
+          0.12873387,
+          0.0380625,
+          0.109947264,
+          0.08717339,
+          0.19043683,
+          0.1692448,
+          0.04412567,
+          0.023771506,
+          0.22656049,
+          0.03954906,
+          0.05286895,
+          0.02503998,
+          0.14083056,
+          0.09264853,
+          0.054106858,
+          0.088258065,
+          0.065104835,
+          0.07398925,
+          0.13041331,
+          0.35306185,
+          0.058637097,
+          0.15837635,
+          0.07660753,
+          0.0791418,
+          0.16538374,
+          0.03179902,
+          0.04344019,
+          0.05092742,
+          0.2874973,
+          0.24587232,
+          0.030950941,
+          0.036038306,
+          0.13807392,
+          0.060127016,
+          0.06549866,
+          0.19372918,
+          0.053521346
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>mae=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "SeasonalNaive",
+         "nbinsx": 100,
+         "offsetgroup": "SeasonalNaive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.059911963,
+          0.101974465,
+          0.089192204,
+          0.15555309,
+          0.120749995,
+          0,
+          0.075658605,
+          0.13581048,
+          0.23766196,
+          0.08882997,
+          0.22642608,
+          0.037919354,
+          0.07332258,
+          0.6364859,
+          0.07985014,
+          0.040171374,
+          0.27476075,
+          0.10197652,
+          0.05643094,
+          0.14255723,
+          0.026644532,
+          0.05894086,
+          0.17605734,
+          0.12947474,
+          0.19166128,
+          0.0736418,
+          0.084257394,
+          0.106717065,
+          0.047866493,
+          0.1491512,
+          0.33030438,
+          0.027988434,
+          0.021466842,
+          0.14376277,
+          0.11156875,
+          0,
+          0.016906777,
+          0,
+          0.14058131,
+          0.09043145,
+          0.124409944,
+          0.10918328,
+          0.09320559,
+          0.15679167,
+          0.11541936,
+          0.12227352,
+          0.23786762,
+          0.08266532,
+          0.07659274,
+          0.066115685,
+          0.057696905,
+          0.058243953,
+          0.06892876,
+          0.1397695,
+          0,
+          0.3264207,
+          0.10119796,
+          0.04240457,
+          0.10952081,
+          0.30698118,
+          0.057208333,
+          0.049051914,
+          0.10649471,
+          0.21842329,
+          0.14714013,
+          0.100362234,
+          0.47646037,
+          0.02889484,
+          0.10726613,
+          0.084573254,
+          0.11243324,
+          0.1319375,
+          0.12487702,
+          0.11660102,
+          0.091092974,
+          0.047315188,
+          0.094819225,
+          0.091046415,
+          0.048395135,
+          0,
+          0.089536965,
+          0.051522877,
+          0.26445833,
+          0.016001914,
+          0.087532155,
+          0.118056454,
+          0.21044825,
+          0.087016806,
+          0.1697715,
+          0.07534163,
+          0.1576859,
+          0.217084,
+          0.05361531,
+          0.15805511,
+          0.15739515,
+          0.21049194,
+          0.07027151,
+          0.055629034,
+          0.27443683,
+          0.075608194,
+          0.062307123,
+          0.073984794,
+          0.019359335,
+          0.10170027,
+          0.29036865,
+          0.22876008,
+          0.19948119,
+          0.27214316,
+          0.1746465,
+          0.22917809,
+          0.05429099,
+          0.1663148,
+          0.17259522,
+          0.20950335,
+          0.045413304,
+          0.11731799,
+          0.09165658,
+          0.40082997,
+          0.27187562,
+          0.071670696,
+          0.07628629,
+          0.22839181,
+          0.05282191,
+          0.10271976,
+          0.049731564,
+          0.17471726,
+          0.1375316,
+          0.070202954,
+          0.105838716,
+          0.08086694,
+          0.07960484,
+          0.23355915,
+          0.23021169,
+          0.07464516,
+          0.29799595,
+          0.1314422,
+          0.09554032,
+          0.20122916,
+          0.08013693,
+          0.049732525,
+          0.043402553,
+          0.49852422,
+          0.32571843,
+          0.047188845,
+          0.041081317,
+          0.0961996,
+          0.20121707,
+          0.09540121,
+          0.22091466,
+          0.110623024
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>mae=%{x}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "SeasonalNaive",
+         "notched": true,
+         "offsetgroup": "SeasonalNaive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.059911963,
+          0.101974465,
+          0.089192204,
+          0.15555309,
+          0.120749995,
+          0,
+          0.075658605,
+          0.13581048,
+          0.23766196,
+          0.08882997,
+          0.22642608,
+          0.037919354,
+          0.07332258,
+          0.6364859,
+          0.07985014,
+          0.040171374,
+          0.27476075,
+          0.10197652,
+          0.05643094,
+          0.14255723,
+          0.026644532,
+          0.05894086,
+          0.17605734,
+          0.12947474,
+          0.19166128,
+          0.0736418,
+          0.084257394,
+          0.106717065,
+          0.047866493,
+          0.1491512,
+          0.33030438,
+          0.027988434,
+          0.021466842,
+          0.14376277,
+          0.11156875,
+          0,
+          0.016906777,
+          0,
+          0.14058131,
+          0.09043145,
+          0.124409944,
+          0.10918328,
+          0.09320559,
+          0.15679167,
+          0.11541936,
+          0.12227352,
+          0.23786762,
+          0.08266532,
+          0.07659274,
+          0.066115685,
+          0.057696905,
+          0.058243953,
+          0.06892876,
+          0.1397695,
+          0,
+          0.3264207,
+          0.10119796,
+          0.04240457,
+          0.10952081,
+          0.30698118,
+          0.057208333,
+          0.049051914,
+          0.10649471,
+          0.21842329,
+          0.14714013,
+          0.100362234,
+          0.47646037,
+          0.02889484,
+          0.10726613,
+          0.084573254,
+          0.11243324,
+          0.1319375,
+          0.12487702,
+          0.11660102,
+          0.091092974,
+          0.047315188,
+          0.094819225,
+          0.091046415,
+          0.048395135,
+          0,
+          0.089536965,
+          0.051522877,
+          0.26445833,
+          0.016001914,
+          0.087532155,
+          0.118056454,
+          0.21044825,
+          0.087016806,
+          0.1697715,
+          0.07534163,
+          0.1576859,
+          0.217084,
+          0.05361531,
+          0.15805511,
+          0.15739515,
+          0.21049194,
+          0.07027151,
+          0.055629034,
+          0.27443683,
+          0.075608194,
+          0.062307123,
+          0.073984794,
+          0.019359335,
+          0.10170027,
+          0.29036865,
+          0.22876008,
+          0.19948119,
+          0.27214316,
+          0.1746465,
+          0.22917809,
+          0.05429099,
+          0.1663148,
+          0.17259522,
+          0.20950335,
+          0.045413304,
+          0.11731799,
+          0.09165658,
+          0.40082997,
+          0.27187562,
+          0.071670696,
+          0.07628629,
+          0.22839181,
+          0.05282191,
+          0.10271976,
+          0.049731564,
+          0.17471726,
+          0.1375316,
+          0.070202954,
+          0.105838716,
+          0.08086694,
+          0.07960484,
+          0.23355915,
+          0.23021169,
+          0.07464516,
+          0.29799595,
+          0.1314422,
+          0.09554032,
+          0.20122916,
+          0.08013693,
+          0.049732525,
+          0.043402553,
+          0.49852422,
+          0.32571843,
+          0.047188845,
+          0.041081317,
+          0.0961996,
+          0.20121707,
+          0.09540121,
+          0.22091466,
+          0.110623024
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of MAE in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0,
+          0.5
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "MAE"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_val_metrics_df_pivot, \n",
+    "                   x=\"mae\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=100, \n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"MAE\", ylabel=\"Probability Density\", title=\"Distribution of MAE in the dataset\")\n",
+    "# fig.write_image(\"imgs/chapter_4/mae_dist.png\")\n",
+    "fig.update_layout(xaxis_range=[0,0.5])\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "955e2346",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>mse=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 500,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.0035607233,
+          0.04069073,
+          0.011811284,
+          0.04897582,
+          0.022801207,
+          0.00020271435,
+          0.012544805,
+          0.03783492,
+          0.1049555,
+          0.014169418,
+          0.0669624,
+          0.0029195163,
+          0.008815695,
+          0.21765547,
+          0.013272159,
+          0.0062670745,
+          0.12039935,
+          0.020466382,
+          0.005993567,
+          0.043798048,
+          0.0064972336,
+          0.008629399,
+          0.037490476,
+          0.019821933,
+          0.0553168,
+          0.014187599,
+          0.014851648,
+          0.025027309,
+          0.004357532,
+          0.025558036,
+          0.07122919,
+          0.0010413316,
+          0.0007914824,
+          0.021497939,
+          0.02202874,
+          0.0030337707,
+          0.0010981078,
+          0.0006378834,
+          0.05439043,
+          0.035274833,
+          0.030470997,
+          0.024602264,
+          0.015863048,
+          0.03904125,
+          0.044434484,
+          0.038624913,
+          0.048996057,
+          0.019717867,
+          0.021076106,
+          0.012964824,
+          0.01275266,
+          0.007425994,
+          0.018035278,
+          0.03449422,
+          0.0000030696535,
+          0.14555971,
+          0.02474248,
+          0.01634491,
+          0.03131132,
+          0.06987433,
+          0.009218098,
+          0.0030183075,
+          0.022860311,
+          0.060438637,
+          0.048273087,
+          0.009350683,
+          0.15904589,
+          0.0025926626,
+          0.011179008,
+          0.01037673,
+          0.016627437,
+          0.030307738,
+          0.0209422,
+          0.023078557,
+          0.02018255,
+          0.005654676,
+          0.019623213,
+          0.008203073,
+          0.008171433,
+          0.00011082899,
+          0.054613635,
+          0.0049262606,
+          0.080612585,
+          0.0004972591,
+          0.015402722,
+          0.022620058,
+          0.042124163,
+          0.016494485,
+          0.038581327,
+          0.021164017,
+          0.026466193,
+          0.051521778,
+          0.004554063,
+          0.021385793,
+          0.05804609,
+          0.046954997,
+          0.019893227,
+          0.00647933,
+          0.11418571,
+          0.01872963,
+          0.004963584,
+          0.01607202,
+          0.00095281494,
+          0.020503756,
+          0.08044191,
+          0.11832366,
+          0.035642795,
+          0.10163158,
+          0.051168647,
+          0.061466105,
+          0.011825725,
+          0.12775147,
+          0.014337141,
+          0.05127847,
+          0.0058741216,
+          0.06040666,
+          0.025542539,
+          0.34219232,
+          0.0844051,
+          0.015206223,
+          0.0043112785,
+          0.3086315,
+          0.0053811325,
+          0.015018232,
+          0.0024470626,
+          0.07725497,
+          0.028748408,
+          0.027515464,
+          0.016971229,
+          0.01796776,
+          0.018373825,
+          0.04636398,
+          0.7411547,
+          0.0088813,
+          0.11550973,
+          0.024517113,
+          0.03405631,
+          0.098613076,
+          0.0071155755,
+          0.005940339,
+          0.00799679,
+          0.22541456,
+          0.13896434,
+          0.0029609348,
+          0.028768681,
+          0.15127309,
+          0.020819152,
+          0.017700238,
+          0.26162663,
+          0.019192645
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>mse=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.0035607233,
+          0.04069073,
+          0.011811284,
+          0.04897582,
+          0.022801207,
+          0.00020271435,
+          0.012544805,
+          0.03783492,
+          0.1049555,
+          0.014169418,
+          0.0669624,
+          0.0029195163,
+          0.008815695,
+          0.21765547,
+          0.013272159,
+          0.0062670745,
+          0.12039935,
+          0.020466382,
+          0.005993567,
+          0.043798048,
+          0.0064972336,
+          0.008629399,
+          0.037490476,
+          0.019821933,
+          0.0553168,
+          0.014187599,
+          0.014851648,
+          0.025027309,
+          0.004357532,
+          0.025558036,
+          0.07122919,
+          0.0010413316,
+          0.0007914824,
+          0.021497939,
+          0.02202874,
+          0.0030337707,
+          0.0010981078,
+          0.0006378834,
+          0.05439043,
+          0.035274833,
+          0.030470997,
+          0.024602264,
+          0.015863048,
+          0.03904125,
+          0.044434484,
+          0.038624913,
+          0.048996057,
+          0.019717867,
+          0.021076106,
+          0.012964824,
+          0.01275266,
+          0.007425994,
+          0.018035278,
+          0.03449422,
+          0.0000030696535,
+          0.14555971,
+          0.02474248,
+          0.01634491,
+          0.03131132,
+          0.06987433,
+          0.009218098,
+          0.0030183075,
+          0.022860311,
+          0.060438637,
+          0.048273087,
+          0.009350683,
+          0.15904589,
+          0.0025926626,
+          0.011179008,
+          0.01037673,
+          0.016627437,
+          0.030307738,
+          0.0209422,
+          0.023078557,
+          0.02018255,
+          0.005654676,
+          0.019623213,
+          0.008203073,
+          0.008171433,
+          0.00011082899,
+          0.054613635,
+          0.0049262606,
+          0.080612585,
+          0.0004972591,
+          0.015402722,
+          0.022620058,
+          0.042124163,
+          0.016494485,
+          0.038581327,
+          0.021164017,
+          0.026466193,
+          0.051521778,
+          0.004554063,
+          0.021385793,
+          0.05804609,
+          0.046954997,
+          0.019893227,
+          0.00647933,
+          0.11418571,
+          0.01872963,
+          0.004963584,
+          0.01607202,
+          0.00095281494,
+          0.020503756,
+          0.08044191,
+          0.11832366,
+          0.035642795,
+          0.10163158,
+          0.051168647,
+          0.061466105,
+          0.011825725,
+          0.12775147,
+          0.014337141,
+          0.05127847,
+          0.0058741216,
+          0.06040666,
+          0.025542539,
+          0.34219232,
+          0.0844051,
+          0.015206223,
+          0.0043112785,
+          0.3086315,
+          0.0053811325,
+          0.015018232,
+          0.0024470626,
+          0.07725497,
+          0.028748408,
+          0.027515464,
+          0.016971229,
+          0.01796776,
+          0.018373825,
+          0.04636398,
+          0.7411547,
+          0.0088813,
+          0.11550973,
+          0.024517113,
+          0.03405631,
+          0.098613076,
+          0.0071155755,
+          0.005940339,
+          0.00799679,
+          0.22541456,
+          0.13896434,
+          0.0029609348,
+          0.028768681,
+          0.15127309,
+          0.020819152,
+          0.017700238,
+          0.26162663,
+          0.019192645
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>mse=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "SeasonalNaive",
+         "nbinsx": 500,
+         "offsetgroup": "SeasonalNaive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.008075674,
+          0.05344917,
+          0.03299938,
+          0.047774814,
+          0.051586844,
+          0,
+          0.016467862,
+          0.05320402,
+          0.17094843,
+          0.021453707,
+          0.15900505,
+          0.0030785818,
+          0.013718274,
+          0.72075284,
+          0.01902377,
+          0.0069778864,
+          0.22420774,
+          0.039834265,
+          0.0076335818,
+          0.052585218,
+          0.005721223,
+          0.011252304,
+          0.07659288,
+          0.058157783,
+          0.079115584,
+          0.024856344,
+          0.025025532,
+          0.038363703,
+          0.00854971,
+          0.058899317,
+          0.22799344,
+          0.0014423085,
+          0.0013924739,
+          0.07831663,
+          0.038123354,
+          0,
+          0.0008048219,
+          0,
+          0.0703609,
+          0.043430094,
+          0.06805136,
+          0.047707908,
+          0.029072331,
+          0.07526738,
+          0.07631444,
+          0.052320674,
+          0.1338116,
+          0.023444494,
+          0.020465268,
+          0.019013697,
+          0.016362593,
+          0.0090449415,
+          0.023435023,
+          0.04502012,
+          0,
+          0.33276653,
+          0.041896712,
+          0.0075569353,
+          0.044608757,
+          0.19823319,
+          0.015942678,
+          0.00468377,
+          0.042438738,
+          0.11821823,
+          0.07921952,
+          0.02561479,
+          0.45818278,
+          0.0030650191,
+          0.026594467,
+          0.020752959,
+          0.036294457,
+          0.047156252,
+          0.053440325,
+          0.044258904,
+          0.024892656,
+          0.009557569,
+          0.031454466,
+          0.017941423,
+          0.0065297536,
+          0,
+          0.05211473,
+          0.0067522684,
+          0.20144969,
+          0.00073401496,
+          0.030923266,
+          0.034572225,
+          0.12430241,
+          0.03164845,
+          0.07441649,
+          0.018367575,
+          0.079687394,
+          0.13652264,
+          0.00962598,
+          0.057575386,
+          0.085942015,
+          0.12669232,
+          0.028348446,
+          0.010482064,
+          0.28618506,
+          0.021408716,
+          0.010768073,
+          0.022825105,
+          0.0010340414,
+          0.033652343,
+          0.17186774,
+          0.16266762,
+          0.1224147,
+          0.16844065,
+          0.10356174,
+          0.14090213,
+          0.014734855,
+          0.15629204,
+          0.07187042,
+          0.108774215,
+          0.0078585595,
+          0.07504613,
+          0.027966058,
+          0.8495874,
+          0.19416012,
+          0.02482382,
+          0.029557493,
+          0.31100512,
+          0.008343439,
+          0.030121837,
+          0.005810722,
+          0.1067691,
+          0.048196316,
+          0.03240477,
+          0.024005445,
+          0.026350792,
+          0.021153115,
+          0.12154029,
+          0.16668808,
+          0.019518618,
+          0.29549596,
+          0.04930469,
+          0.042170126,
+          0.13470441,
+          0.018145008,
+          0.010023363,
+          0.0076531377,
+          0.562285,
+          0.2203284,
+          0.005246694,
+          0.027854523,
+          0.04842709,
+          0.13589002,
+          0.028323486,
+          0.2909431,
+          0.051093183
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>mse=%{x}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "SeasonalNaive",
+         "notched": true,
+         "offsetgroup": "SeasonalNaive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.008075674,
+          0.05344917,
+          0.03299938,
+          0.047774814,
+          0.051586844,
+          0,
+          0.016467862,
+          0.05320402,
+          0.17094843,
+          0.021453707,
+          0.15900505,
+          0.0030785818,
+          0.013718274,
+          0.72075284,
+          0.01902377,
+          0.0069778864,
+          0.22420774,
+          0.039834265,
+          0.0076335818,
+          0.052585218,
+          0.005721223,
+          0.011252304,
+          0.07659288,
+          0.058157783,
+          0.079115584,
+          0.024856344,
+          0.025025532,
+          0.038363703,
+          0.00854971,
+          0.058899317,
+          0.22799344,
+          0.0014423085,
+          0.0013924739,
+          0.07831663,
+          0.038123354,
+          0,
+          0.0008048219,
+          0,
+          0.0703609,
+          0.043430094,
+          0.06805136,
+          0.047707908,
+          0.029072331,
+          0.07526738,
+          0.07631444,
+          0.052320674,
+          0.1338116,
+          0.023444494,
+          0.020465268,
+          0.019013697,
+          0.016362593,
+          0.0090449415,
+          0.023435023,
+          0.04502012,
+          0,
+          0.33276653,
+          0.041896712,
+          0.0075569353,
+          0.044608757,
+          0.19823319,
+          0.015942678,
+          0.00468377,
+          0.042438738,
+          0.11821823,
+          0.07921952,
+          0.02561479,
+          0.45818278,
+          0.0030650191,
+          0.026594467,
+          0.020752959,
+          0.036294457,
+          0.047156252,
+          0.053440325,
+          0.044258904,
+          0.024892656,
+          0.009557569,
+          0.031454466,
+          0.017941423,
+          0.0065297536,
+          0,
+          0.05211473,
+          0.0067522684,
+          0.20144969,
+          0.00073401496,
+          0.030923266,
+          0.034572225,
+          0.12430241,
+          0.03164845,
+          0.07441649,
+          0.018367575,
+          0.079687394,
+          0.13652264,
+          0.00962598,
+          0.057575386,
+          0.085942015,
+          0.12669232,
+          0.028348446,
+          0.010482064,
+          0.28618506,
+          0.021408716,
+          0.010768073,
+          0.022825105,
+          0.0010340414,
+          0.033652343,
+          0.17186774,
+          0.16266762,
+          0.1224147,
+          0.16844065,
+          0.10356174,
+          0.14090213,
+          0.014734855,
+          0.15629204,
+          0.07187042,
+          0.108774215,
+          0.0078585595,
+          0.07504613,
+          0.027966058,
+          0.8495874,
+          0.19416012,
+          0.02482382,
+          0.029557493,
+          0.31100512,
+          0.008343439,
+          0.030121837,
+          0.005810722,
+          0.1067691,
+          0.048196316,
+          0.03240477,
+          0.024005445,
+          0.026350792,
+          0.021153115,
+          0.12154029,
+          0.16668808,
+          0.019518618,
+          0.29549596,
+          0.04930469,
+          0.042170126,
+          0.13470441,
+          0.018145008,
+          0.010023363,
+          0.0076531377,
+          0.562285,
+          0.2203284,
+          0.005246694,
+          0.027854523,
+          0.04842709,
+          0.13589002,
+          0.028323486,
+          0.2909431,
+          0.051093183
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of MSE in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0,
+          0.6
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "MSE"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_val_metrics_df_pivot, \n",
+    "                   x=\"mse\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=500, \n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"MSE\", ylabel=\"Probability Density\", title=\"Distribution of MSE in the dataset\")\n",
+    "fig.update_layout(xaxis_range=[0,0.6])\n",
+    "# fig.write_image(\"imgs/chapter_4/mse_dist.png\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "0813e995",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>metric</th>\n",
+       "      <th>LCLid</th>\n",
+       "      <th>Algorithm</th>\n",
+       "      <th>forecast_bias</th>\n",
+       "      <th>mae</th>\n",
+       "      <th>mase</th>\n",
+       "      <th>mse</th>\n",
+       "      <th>rmse</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000591</td>\n",
+       "      <td>0.033290</td>\n",
+       "      <td>0.954536</td>\n",
+       "      <td>0.003561</td>\n",
+       "      <td>0.059672</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>MAC000061</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.028300</td>\n",
+       "      <td>0.059912</td>\n",
+       "      <td>1.717861</td>\n",
+       "      <td>0.008076</td>\n",
+       "      <td>0.089865</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000767</td>\n",
+       "      <td>0.088534</td>\n",
+       "      <td>1.167550</td>\n",
+       "      <td>0.040691</td>\n",
+       "      <td>0.201719</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>MAC000062</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>-0.003600</td>\n",
+       "      <td>0.101974</td>\n",
+       "      <td>1.344793</td>\n",
+       "      <td>0.053449</td>\n",
+       "      <td>0.231191</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MAC000066</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000574</td>\n",
+       "      <td>0.043099</td>\n",
+       "      <td>1.110772</td>\n",
+       "      <td>0.011811</td>\n",
+       "      <td>0.108680</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>295</th>\n",
+       "      <td>MAC005463</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.003513</td>\n",
+       "      <td>0.095401</td>\n",
+       "      <td>1.675904</td>\n",
+       "      <td>0.028323</td>\n",
+       "      <td>0.168296</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>296</th>\n",
+       "      <td>MAC005521</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000771</td>\n",
+       "      <td>0.193729</td>\n",
+       "      <td>1.465386</td>\n",
+       "      <td>0.261627</td>\n",
+       "      <td>0.511495</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>297</th>\n",
+       "      <td>MAC005521</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.067720</td>\n",
+       "      <td>0.220915</td>\n",
+       "      <td>1.671020</td>\n",
+       "      <td>0.290943</td>\n",
+       "      <td>0.539391</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>298</th>\n",
+       "      <td>MAC005529</td>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.000047</td>\n",
+       "      <td>0.053521</td>\n",
+       "      <td>0.992287</td>\n",
+       "      <td>0.019193</td>\n",
+       "      <td>0.138538</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>299</th>\n",
+       "      <td>MAC005529</td>\n",
+       "      <td>SeasonalNaive</td>\n",
+       "      <td>0.004557</td>\n",
+       "      <td>0.110623</td>\n",
+       "      <td>2.050953</td>\n",
+       "      <td>0.051093</td>\n",
+       "      <td>0.226038</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>300 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "metric      LCLid      Algorithm  forecast_bias       mae      mase       mse  \\\n",
+       "0       MAC000061          Naive       0.000591  0.033290  0.954536  0.003561   \n",
+       "1       MAC000061  SeasonalNaive       0.028300  0.059912  1.717861  0.008076   \n",
+       "2       MAC000062          Naive       0.000767  0.088534  1.167550  0.040691   \n",
+       "3       MAC000062  SeasonalNaive      -0.003600  0.101974  1.344793  0.053449   \n",
+       "4       MAC000066          Naive       0.000574  0.043099  1.110772  0.011811   \n",
+       "..            ...            ...            ...       ...       ...       ...   \n",
+       "295     MAC005463  SeasonalNaive       0.003513  0.095401  1.675904  0.028323   \n",
+       "296     MAC005521          Naive       0.000771  0.193729  1.465386  0.261627   \n",
+       "297     MAC005521  SeasonalNaive       0.067720  0.220915  1.671020  0.290943   \n",
+       "298     MAC005529          Naive       0.000047  0.053521  0.992287  0.019193   \n",
+       "299     MAC005529  SeasonalNaive       0.004557  0.110623  2.050953  0.051093   \n",
+       "\n",
+       "metric      rmse  \n",
+       "0       0.059672  \n",
+       "1       0.089865  \n",
+       "2       0.201719  \n",
+       "3       0.231191  \n",
+       "4       0.108680  \n",
+       "..           ...  \n",
+       "295     0.168296  \n",
+       "296     0.511495  \n",
+       "297     0.539391  \n",
+       "298     0.138538  \n",
+       "299     0.226038  \n",
+       "\n",
+       "[300 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_val_metrics_df_pivot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "c693a963",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>forecast_bias=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 250,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.00059104525,
+          0.0007674715,
+          0.00057430094,
+          -0.00008481549,
+          0.00071033847,
+          -9.739033e-7,
+          0.0025386973,
+          0.00028858613,
+          -0.00026055664,
+          0.00048452633,
+          0.00011794732,
+          0.000042729167,
+          0.0006943381,
+          -0.0011141668,
+          -0.0006037737,
+          0.00036882152,
+          -0.0006191404,
+          0.00052329287,
+          -0.00008014564,
+          0.0004314936,
+          0.000011815541,
+          -0.00020711031,
+          -0.00031295273,
+          0.000026782529,
+          -0.00002696529,
+          0.00014194917,
+          -0.00020509011,
+          0.00028370382,
+          0.0000063129246,
+          -0.00032803527,
+          0.0002198751,
+          0.00002605301,
+          -0.00005919861,
+          0.0001278596,
+          0.00023771399,
+          0.000021371501,
+          0.00046428206,
+          0.00024296557,
+          -0.00032726853,
+          0.00016254553,
+          0.000263044,
+          0.0003175653,
+          -0.00031955083,
+          -0.000011534541,
+          0.00030026597,
+          0.00011140213,
+          0.00015052385,
+          0.00014842169,
+          0.0003540949,
+          -0.00034630095,
+          -0.00028021817,
+          -0.0006520107,
+          -0.0044745393,
+          0.00039903412,
+          0.00009698917,
+          0.00010281029,
+          -0.00006751148,
+          -0.00010197299,
+          -0.0003995152,
+          -0.0002751486,
+          0.00015977789,
+          -0.00030705277,
+          0.00091900636,
+          0.00004623042,
+          -0.000115879004,
+          0,
+          -0.0010194776,
+          0.00063293293,
+          0.0004379215,
+          0.00012460056,
+          0.0005785979,
+          0.00013617869,
+          0.000052283445,
+          -0.00029518007,
+          0.00027747915,
+          0.00014174594,
+          -0.00013641758,
+          0.0006119772,
+          -0.00019822137,
+          -0.00012845878,
+          0.0008408678,
+          0.00046486722,
+          0.00020843322,
+          0.00070274493,
+          0.001040628,
+          -0.0009048657,
+          0.00024168707,
+          0.0002643201,
+          0.000010496452,
+          -0.000067654,
+          0.00080023124,
+          0.00014810049,
+          0.0001570434,
+          0.0010372224,
+          -0.00021705184,
+          -0.00006984556,
+          0.000022799079,
+          0.00006399732,
+          0.00057215575,
+          0.00007912915,
+          -0.00004678883,
+          -0.0012907507,
+          0.000096892654,
+          0.00036787917,
+          -0.000109331,
+          -0.0004932335,
+          0.0017858254,
+          0.00052696274,
+          -0.00022895698,
+          -0.00022251181,
+          -0.00015428335,
+          0.00026457073,
+          0.00001938493,
+          -0.00073793245,
+          0.00066041615,
+          0.00013824573,
+          0.00010395729,
+          -0.000006721171,
+          -0.0009064763,
+          0.00003823861,
+          -0.00011915958,
+          0.00005417606,
+          0.00037467558,
+          -0.003492909,
+          0.00006827036,
+          -0.00040881603,
+          -0.00055182795,
+          -0.000102996644,
+          0.0000303144,
+          -0.00008043531,
+          -0.00083418406,
+          -0.000049806735,
+          0.00008711024,
+          0.00006105006,
+          0.00012397932,
+          0.000722022,
+          0.00068581407,
+          0.00022203084,
+          -0.0003186355,
+          0.0004559223,
+          0.00010761429,
+          -0.0002776103,
+          -0.0003238985,
+          -0.00023657858,
+          -0.000008595872,
+          -0.00024666288,
+          -0.0001411207,
+          0.0012585925,
+          0.00077072426,
+          0.000046679274
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>forecast_bias=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.00059104525,
+          0.0007674715,
+          0.00057430094,
+          -0.00008481549,
+          0.00071033847,
+          -9.739033e-7,
+          0.0025386973,
+          0.00028858613,
+          -0.00026055664,
+          0.00048452633,
+          0.00011794732,
+          0.000042729167,
+          0.0006943381,
+          -0.0011141668,
+          -0.0006037737,
+          0.00036882152,
+          -0.0006191404,
+          0.00052329287,
+          -0.00008014564,
+          0.0004314936,
+          0.000011815541,
+          -0.00020711031,
+          -0.00031295273,
+          0.000026782529,
+          -0.00002696529,
+          0.00014194917,
+          -0.00020509011,
+          0.00028370382,
+          0.0000063129246,
+          -0.00032803527,
+          0.0002198751,
+          0.00002605301,
+          -0.00005919861,
+          0.0001278596,
+          0.00023771399,
+          0.000021371501,
+          0.00046428206,
+          0.00024296557,
+          -0.00032726853,
+          0.00016254553,
+          0.000263044,
+          0.0003175653,
+          -0.00031955083,
+          -0.000011534541,
+          0.00030026597,
+          0.00011140213,
+          0.00015052385,
+          0.00014842169,
+          0.0003540949,
+          -0.00034630095,
+          -0.00028021817,
+          -0.0006520107,
+          -0.0044745393,
+          0.00039903412,
+          0.00009698917,
+          0.00010281029,
+          -0.00006751148,
+          -0.00010197299,
+          -0.0003995152,
+          -0.0002751486,
+          0.00015977789,
+          -0.00030705277,
+          0.00091900636,
+          0.00004623042,
+          -0.000115879004,
+          0,
+          -0.0010194776,
+          0.00063293293,
+          0.0004379215,
+          0.00012460056,
+          0.0005785979,
+          0.00013617869,
+          0.000052283445,
+          -0.00029518007,
+          0.00027747915,
+          0.00014174594,
+          -0.00013641758,
+          0.0006119772,
+          -0.00019822137,
+          -0.00012845878,
+          0.0008408678,
+          0.00046486722,
+          0.00020843322,
+          0.00070274493,
+          0.001040628,
+          -0.0009048657,
+          0.00024168707,
+          0.0002643201,
+          0.000010496452,
+          -0.000067654,
+          0.00080023124,
+          0.00014810049,
+          0.0001570434,
+          0.0010372224,
+          -0.00021705184,
+          -0.00006984556,
+          0.000022799079,
+          0.00006399732,
+          0.00057215575,
+          0.00007912915,
+          -0.00004678883,
+          -0.0012907507,
+          0.000096892654,
+          0.00036787917,
+          -0.000109331,
+          -0.0004932335,
+          0.0017858254,
+          0.00052696274,
+          -0.00022895698,
+          -0.00022251181,
+          -0.00015428335,
+          0.00026457073,
+          0.00001938493,
+          -0.00073793245,
+          0.00066041615,
+          0.00013824573,
+          0.00010395729,
+          -0.000006721171,
+          -0.0009064763,
+          0.00003823861,
+          -0.00011915958,
+          0.00005417606,
+          0.00037467558,
+          -0.003492909,
+          0.00006827036,
+          -0.00040881603,
+          -0.00055182795,
+          -0.000102996644,
+          0.0000303144,
+          -0.00008043531,
+          -0.00083418406,
+          -0.000049806735,
+          0.00008711024,
+          0.00006105006,
+          0.00012397932,
+          0.000722022,
+          0.00068581407,
+          0.00022203084,
+          -0.0003186355,
+          0.0004559223,
+          0.00010761429,
+          -0.0002776103,
+          -0.0003238985,
+          -0.00023657858,
+          -0.000008595872,
+          -0.00024666288,
+          -0.0001411207,
+          0.0012585925,
+          0.00077072426,
+          0.000046679274
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>forecast_bias=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "SeasonalNaive",
+         "nbinsx": 250,
+         "offsetgroup": "SeasonalNaive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.028300155,
+          -0.00360015,
+          0.17725857,
+          0.02280819,
+          0.02204522,
+          0,
+          0.022373782,
+          0.06612882,
+          -0.047960605,
+          -0.012487221,
+          0.0054926495,
+          0.009665093,
+          0.038840882,
+          -0.15567829,
+          -0.03160542,
+          0.0062955823,
+          0.076784015,
+          -0.024122933,
+          0.0018629734,
+          -0.019236369,
+          -0.022651022,
+          0.049081482,
+          0.014730393,
+          -0.13069914,
+          -0.011145349,
+          0.036080044,
+          -0.12670924,
+          -0.09045462,
+          -0.0033348503,
+          -0.017924443,
+          0.023107989,
+          -0.016396359,
+          -0.05834266,
+          0.059339322,
+          -0.006557256,
+          0,
+          0.012326455,
+          0,
+          0.018950077,
+          0.026609996,
+          -0.072119124,
+          -0.04115982,
+          0.014215441,
+          0.009919441,
+          -0.05747479,
+          -0.085003614,
+          0.07670404,
+          0.030446965,
+          -0.008239314,
+          0.08598523,
+          0.022440344,
+          -0.027090462,
+          -0.17322667,
+          -0.01715337,
+          0,
+          -0.27221742,
+          0.0017112357,
+          0.014102,
+          0.024531415,
+          -0.1072248,
+          -0.0126293525,
+          0.019947624,
+          0.06601781,
+          0.05946351,
+          0.020745462,
+          -0.029608423,
+          -0.0077481945,
+          -0.012963787,
+          -0.01868842,
+          0.076055996,
+          -0.032945704,
+          0.07100729,
+          0.06323962,
+          0.030103983,
+          -0.0014097085,
+          0.019777346,
+          0.03283418,
+          0.008201756,
+          0.03772786,
+          0,
+          -0.022326324,
+          -0.07083704,
+          -0.023547128,
+          0.020350223,
+          0.030145459,
+          0.028487977,
+          0.16977504,
+          -0.044764798,
+          0.06949498,
+          -0.014966541,
+          -0.037391387,
+          0.25956577,
+          0.031873748,
+          0.0057048462,
+          -0.0037072455,
+          0.082556784,
+          -0.15765904,
+          0.05173726,
+          0.04539363,
+          -0.00039262557,
+          0.00016114391,
+          0.01379685,
+          -0.020302642,
+          -0.014942173,
+          -0.04593566,
+          0.03953663,
+          0.22770602,
+          -0.0565297,
+          0.010423228,
+          0.05023867,
+          -0.04698892,
+          0.026056968,
+          0.0072002015,
+          -0.053826533,
+          -0.0065442068,
+          -0.011035611,
+          -0.050774444,
+          -0.14730108,
+          0.027364518,
+          0.010821111,
+          -0.27203092,
+          -0.16853955,
+          0.08552336,
+          -0.14096323,
+          0.032765087,
+          -0.12993214,
+          0.05702398,
+          0.32032958,
+          -0.026653416,
+          -0.0030319206,
+          0.032494318,
+          0.112654485,
+          -0.029967405,
+          -0.026826946,
+          -0.2803948,
+          0.20852803,
+          0.0415918,
+          0.006737134,
+          0.07485504,
+          0.008903211,
+          -0.13293697,
+          -0.047643647,
+          0.00008854187,
+          -0.062433712,
+          -0.003104816,
+          0.025746403,
+          -0.1389229,
+          0.0035134966,
+          0.067719735,
+          0.004556871
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=SeasonalNaive<br>forecast_bias=%{x}<extra></extra>",
+         "legendgroup": "SeasonalNaive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "SeasonalNaive",
+         "notched": true,
+         "offsetgroup": "SeasonalNaive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.028300155,
+          -0.00360015,
+          0.17725857,
+          0.02280819,
+          0.02204522,
+          0,
+          0.022373782,
+          0.06612882,
+          -0.047960605,
+          -0.012487221,
+          0.0054926495,
+          0.009665093,
+          0.038840882,
+          -0.15567829,
+          -0.03160542,
+          0.0062955823,
+          0.076784015,
+          -0.024122933,
+          0.0018629734,
+          -0.019236369,
+          -0.022651022,
+          0.049081482,
+          0.014730393,
+          -0.13069914,
+          -0.011145349,
+          0.036080044,
+          -0.12670924,
+          -0.09045462,
+          -0.0033348503,
+          -0.017924443,
+          0.023107989,
+          -0.016396359,
+          -0.05834266,
+          0.059339322,
+          -0.006557256,
+          0,
+          0.012326455,
+          0,
+          0.018950077,
+          0.026609996,
+          -0.072119124,
+          -0.04115982,
+          0.014215441,
+          0.009919441,
+          -0.05747479,
+          -0.085003614,
+          0.07670404,
+          0.030446965,
+          -0.008239314,
+          0.08598523,
+          0.022440344,
+          -0.027090462,
+          -0.17322667,
+          -0.01715337,
+          0,
+          -0.27221742,
+          0.0017112357,
+          0.014102,
+          0.024531415,
+          -0.1072248,
+          -0.0126293525,
+          0.019947624,
+          0.06601781,
+          0.05946351,
+          0.020745462,
+          -0.029608423,
+          -0.0077481945,
+          -0.012963787,
+          -0.01868842,
+          0.076055996,
+          -0.032945704,
+          0.07100729,
+          0.06323962,
+          0.030103983,
+          -0.0014097085,
+          0.019777346,
+          0.03283418,
+          0.008201756,
+          0.03772786,
+          0,
+          -0.022326324,
+          -0.07083704,
+          -0.023547128,
+          0.020350223,
+          0.030145459,
+          0.028487977,
+          0.16977504,
+          -0.044764798,
+          0.06949498,
+          -0.014966541,
+          -0.037391387,
+          0.25956577,
+          0.031873748,
+          0.0057048462,
+          -0.0037072455,
+          0.082556784,
+          -0.15765904,
+          0.05173726,
+          0.04539363,
+          -0.00039262557,
+          0.00016114391,
+          0.01379685,
+          -0.020302642,
+          -0.014942173,
+          -0.04593566,
+          0.03953663,
+          0.22770602,
+          -0.0565297,
+          0.010423228,
+          0.05023867,
+          -0.04698892,
+          0.026056968,
+          0.0072002015,
+          -0.053826533,
+          -0.0065442068,
+          -0.011035611,
+          -0.050774444,
+          -0.14730108,
+          0.027364518,
+          0.010821111,
+          -0.27203092,
+          -0.16853955,
+          0.08552336,
+          -0.14096323,
+          0.032765087,
+          -0.12993214,
+          0.05702398,
+          0.32032958,
+          -0.026653416,
+          -0.0030319206,
+          0.032494318,
+          0.112654485,
+          -0.029967405,
+          -0.026826946,
+          -0.2803948,
+          0.20852803,
+          0.0415918,
+          0.006737134,
+          0.07485504,
+          0.008903211,
+          -0.13293697,
+          -0.047643647,
+          0.00008854187,
+          -0.062433712,
+          -0.003104816,
+          0.025746403,
+          -0.1389229,
+          0.0035134966,
+          0.067719735,
+          0.004556871
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of Forecast Bias in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          -20,
+          20
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Forecast Bias"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_val_metrics_df_pivot, \n",
+    "                   x=\"forecast_bias\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=250,\n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"Forecast Bias\", ylabel=\"Probability Density\", title=\"Distribution of Forecast Bias in the dataset\")\n",
+    "fig.update_layout(xaxis_range=[-40,40])\n",
+    "# fig.write_image(\"imgs/chapter_4/bias_dist.png\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65014ca0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86f2e188",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de0a9c91",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "15c25f33-a1c5-4217-9d28-30ee21bdfef3",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'naive_pred_val_df' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[62], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m baseline_pred_val_df \u001b[38;5;241m=\u001b[39m \u001b[43mnaive_pred_val_df\u001b[49m\u001b[38;5;241m.\u001b[39mreset_index()\u001b[38;5;241m.\u001b[39mmerge(snaive_pred_val_df\u001b[38;5;241m.\u001b[39mreset_index()\u001b[38;5;241m.\u001b[39mdrop(columns\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124menergy_consumption\u001b[39m\u001b[38;5;124m'\u001b[39m), on\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mtimestamp\u001b[39m\u001b[38;5;124m'\u001b[39m,\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mLCLid\u001b[39m\u001b[38;5;124m'\u001b[39m], how\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mouter\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m      2\u001b[0m baseline_pred_test_df \u001b[38;5;241m=\u001b[39m naive_pred_test_df\u001b[38;5;241m.\u001b[39mreset_index()\u001b[38;5;241m.\u001b[39mmerge(snaive_pred_test_df\u001b[38;5;241m.\u001b[39mreset_index()\u001b[38;5;241m.\u001b[39mdrop(columns\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124menergy_consumption\u001b[39m\u001b[38;5;124m'\u001b[39m), on\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mtimestamp\u001b[39m\u001b[38;5;124m'\u001b[39m,\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mLCLid\u001b[39m\u001b[38;5;124m'\u001b[39m], how\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mouter\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'naive_pred_val_df' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "baseline_pred_val_df = naive_pred_val_df.reset_index().merge(snaive_pred_val_df.reset_index().drop(columns='energy_consumption'), on=['timestamp','LCLid'], how='outer')\n",
+    "baseline_pred_test_df = naive_pred_test_df.reset_index().merge(snaive_pred_test_df.reset_index().drop(columns='energy_consumption'), on=['timestamp','LCLid'], how='outer')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "eb9ece72-317f-4f1c-ae78-8d459cf358e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Algorithm</th>\n",
+       "      <th>MAE</th>\n",
+       "      <th>MSE</th>\n",
+       "      <th>MASE</th>\n",
+       "      <th>Forecast Bias</th>\n",
+       "      <th>LCLid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.033290</td>\n",
+       "      <td>0.003561</td>\n",
+       "      <td>0.952700</td>\n",
+       "      <td>-0.059105</td>\n",
+       "      <td>MAC000061</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.088534</td>\n",
+       "      <td>0.040691</td>\n",
+       "      <td>1.175905</td>\n",
+       "      <td>-0.076755</td>\n",
+       "      <td>MAC000062</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.043099</td>\n",
+       "      <td>0.011811</td>\n",
+       "      <td>1.116015</td>\n",
+       "      <td>-0.057436</td>\n",
+       "      <td>MAC000066</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.167172</td>\n",
+       "      <td>0.048976</td>\n",
+       "      <td>1.945080</td>\n",
+       "      <td>0.008482</td>\n",
+       "      <td>MAC000086</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Naive</td>\n",
+       "      <td>0.071154</td>\n",
+       "      <td>0.022801</td>\n",
+       "      <td>1.078793</td>\n",
+       "      <td>-0.071034</td>\n",
+       "      <td>MAC000126</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Algorithm       MAE       MSE      MASE  Forecast Bias      LCLid\n",
+       "0     Naive  0.033290  0.003561  0.952700      -0.059105  MAC000061\n",
+       "1     Naive  0.088534  0.040691  1.175905      -0.076755  MAC000062\n",
+       "2     Naive  0.043099  0.011811  1.116015      -0.057436  MAC000066\n",
+       "3     Naive  0.167172  0.048976  1.945080       0.008482  MAC000086\n",
+       "4     Naive  0.071154  0.022801  1.078793      -0.071034  MAC000126"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_metrics_val_df = pd.concat([naive_metric_val_df, snaive_metric_val_df])\n",
+    "baseline_metrics_test_df = pd.concat([naive_metric_test_df, snaive_metric_test_df])\n",
+    "baseline_metrics_val_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "9d164184-dca3-4472-a138-c260019eeb68",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>MASE=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 500,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.95269954,
+          1.1759052,
+          1.1160151,
+          1.9450796,
+          1.0787929,
+          0.23467226,
+          1.1208345,
+          1.3526492,
+          1.3664031,
+          0.7197451,
+          1.1050453,
+          0.94198525,
+          1.0131155,
+          1.7104492,
+          1.127431,
+          1.2604164,
+          1.2696214,
+          1.2164861,
+          0.8914518,
+          1.0945295,
+          1.2152666,
+          1.2085943,
+          1.0835178,
+          1.4527597,
+          1.0278497,
+          0.96701354,
+          1.055257,
+          1.0722649,
+          1.2156923,
+          1.0959979,
+          1.0398701,
+          0.8309649,
+          1.023581,
+          0.93777335,
+          1.0316265,
+          0.4389036,
+          0.931833,
+          0.22835727,
+          1.2669079,
+          0.8768616,
+          1.1658173,
+          1.0996568,
+          0.89278734,
+          1.2732979,
+          0.8666789,
+          1.3284075,
+          1.2443181,
+          0.88255376,
+          1.0159419,
+          0.7616833,
+          1.5902745,
+          1.1155479,
+          1.1661569,
+          1.1909099,
+          0.43079573,
+          4.2088976,
+          0.91630286,
+          1.0989761,
+          1.1784879,
+          1.261671,
+          0.84394014,
+          1.0355341,
+          1.7261953,
+          1.3895744,
+          1.2170906,
+          1.1924877,
+          0.9314608,
+          0.83456457,
+          0.9649038,
+          1.2668155,
+          1.0401067,
+          1.069783,
+          0.64591545,
+          0.7878734,
+          1.0490593,
+          0.7050088,
+          1.1403037,
+          1.0332069,
+          1.0887485,
+          0.18108113,
+          1.0691345,
+          1.009142,
+          1.2253587,
+          1.4438057,
+          1.3829623,
+          0.98414767,
+          1.2020657,
+          0.95277834,
+          0.9809872,
+          1.0693574,
+          1.2437798,
+          1.07248,
+          0.95188516,
+          1.0027802,
+          1.0881889,
+          1.189009,
+          0.98894036,
+          0.8834117,
+          1.4075491,
+          1.3313946,
+          1.0886611,
+          0.9731617,
+          1.2760881,
+          1.049904,
+          1.2574562,
+          1.237827,
+          0.91548437,
+          1.0954062,
+          1.0638472,
+          1.3624252,
+          1.2190709,
+          0.85357714,
+          1.2760576,
+          1.2721784,
+          0.8426097,
+          1.240912,
+          1.0797926,
+          1.269362,
+          1.149179,
+          0.74922115,
+          0.1818053,
+          1.1449676,
+          1.1994002,
+          1.4921566,
+          0.8920925,
+          1.0367858,
+          1.059456,
+          0.86114174,
+          1.2287441,
+          1.2341787,
+          0.9887183,
+          1.1350838,
+          1.3111997,
+          0.96878296,
+          1.032602,
+          1.0156322,
+          0.9881356,
+          1.0676807,
+          1.381086,
+          1.0030452,
+          0.9623618,
+          1.4262636,
+          1.0386374,
+          0.93703455,
+          1.0433161,
+          1.5443376,
+          1.0991937,
+          1.159283,
+          1.500126,
+          0.99190605
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>MASE=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.95269954,
+          1.1759052,
+          1.1160151,
+          1.9450796,
+          1.0787929,
+          0.23467226,
+          1.1208345,
+          1.3526492,
+          1.3664031,
+          0.7197451,
+          1.1050453,
+          0.94198525,
+          1.0131155,
+          1.7104492,
+          1.127431,
+          1.2604164,
+          1.2696214,
+          1.2164861,
+          0.8914518,
+          1.0945295,
+          1.2152666,
+          1.2085943,
+          1.0835178,
+          1.4527597,
+          1.0278497,
+          0.96701354,
+          1.055257,
+          1.0722649,
+          1.2156923,
+          1.0959979,
+          1.0398701,
+          0.8309649,
+          1.023581,
+          0.93777335,
+          1.0316265,
+          0.4389036,
+          0.931833,
+          0.22835727,
+          1.2669079,
+          0.8768616,
+          1.1658173,
+          1.0996568,
+          0.89278734,
+          1.2732979,
+          0.8666789,
+          1.3284075,
+          1.2443181,
+          0.88255376,
+          1.0159419,
+          0.7616833,
+          1.5902745,
+          1.1155479,
+          1.1661569,
+          1.1909099,
+          0.43079573,
+          4.2088976,
+          0.91630286,
+          1.0989761,
+          1.1784879,
+          1.261671,
+          0.84394014,
+          1.0355341,
+          1.7261953,
+          1.3895744,
+          1.2170906,
+          1.1924877,
+          0.9314608,
+          0.83456457,
+          0.9649038,
+          1.2668155,
+          1.0401067,
+          1.069783,
+          0.64591545,
+          0.7878734,
+          1.0490593,
+          0.7050088,
+          1.1403037,
+          1.0332069,
+          1.0887485,
+          0.18108113,
+          1.0691345,
+          1.009142,
+          1.2253587,
+          1.4438057,
+          1.3829623,
+          0.98414767,
+          1.2020657,
+          0.95277834,
+          0.9809872,
+          1.0693574,
+          1.2437798,
+          1.07248,
+          0.95188516,
+          1.0027802,
+          1.0881889,
+          1.189009,
+          0.98894036,
+          0.8834117,
+          1.4075491,
+          1.3313946,
+          1.0886611,
+          0.9731617,
+          1.2760881,
+          1.049904,
+          1.2574562,
+          1.237827,
+          0.91548437,
+          1.0954062,
+          1.0638472,
+          1.3624252,
+          1.2190709,
+          0.85357714,
+          1.2760576,
+          1.2721784,
+          0.8426097,
+          1.240912,
+          1.0797926,
+          1.269362,
+          1.149179,
+          0.74922115,
+          0.1818053,
+          1.1449676,
+          1.1994002,
+          1.4921566,
+          0.8920925,
+          1.0367858,
+          1.059456,
+          0.86114174,
+          1.2287441,
+          1.2341787,
+          0.9887183,
+          1.1350838,
+          1.3111997,
+          0.96878296,
+          1.032602,
+          1.0156322,
+          0.9881356,
+          1.0676807,
+          1.381086,
+          1.0030452,
+          0.9623618,
+          1.4262636,
+          1.0386374,
+          0.93703455,
+          1.0433161,
+          1.5443376,
+          1.0991937,
+          1.159283,
+          1.500126,
+          0.99190605
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>MASE=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "Seasonal Naive",
+         "nbinsx": 500,
+         "offsetgroup": "Seasonal Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          1.7145553,
+          1.3544167,
+          2.3095381,
+          1.8098906,
+          1.8307394,
+          0,
+          1.3096373,
+          1.7109916,
+          1.852141,
+          0.84276956,
+          1.9059796,
+          0.98002315,
+          1.2882712,
+          3.5844228,
+          1.3714103,
+          1.3202732,
+          1.8058187,
+          1.7579752,
+          1.2251116,
+          1.2234967,
+          1.2444086,
+          1.4959503,
+          1.882116,
+          2.6898048,
+          1.4574671,
+          1.1425838,
+          1.4926367,
+          1.4558616,
+          1.9286319,
+          1.7739906,
+          2.1538959,
+          0.9610327,
+          1.3115172,
+          2.0173118,
+          1.4737532,
+          0,
+          0.7874026,
+          0,
+          1.7353317,
+          1.102134,
+          1.7477158,
+          1.7486188,
+          1.2310658,
+          1.9036965,
+          1.224231,
+          1.7169089,
+          2.3592486,
+          0.9404946,
+          1.108985,
+          1.0310267,
+          1.7867357,
+          1.1324563,
+          1.3195217,
+          1.4282197,
+          0,
+          7.300752,
+          1.2031935,
+          0.72668505,
+          1.4143418,
+          2.3315835,
+          1.1547254,
+          1.5492176,
+          2.688156,
+          2.2100701,
+          1.7035667,
+          2.3963847,
+          1.8152696,
+          0.8742443,
+          1.6345637,
+          1.8423308,
+          1.8370812,
+          1.4898417,
+          1.2302006,
+          1.2733743,
+          1.2831849,
+          0.8383917,
+          1.4617414,
+          1.4710169,
+          1.0173,
+          0,
+          1.2209371,
+          1.2160763,
+          2.1888838,
+          1.8471049,
+          1.955696,
+          1.5006967,
+          2.081538,
+          1.4060807,
+          1.4594125,
+          1.0049311,
+          2.819688,
+          1.7650146,
+          1.4515151,
+          1.6889135,
+          1.4750956,
+          2.1078205,
+          1.3811429,
+          1.1252987,
+          2.7839432,
+          1.4371789,
+          1.7260296,
+          1.2187903,
+          1.2654816,
+          1.390372,
+          2.0104098,
+          1.6046541,
+          1.9568183,
+          1.5563737,
+          1.7191355,
+          2.0706584,
+          1.5630431,
+          1.01686,
+          4.5651608,
+          2.0703616,
+          1.0053384,
+          1.3241011,
+          1.1353248,
+          2.6717432,
+          1.8460462,
+          1.2169152,
+          0.5834401,
+          1.1542225,
+          1.6019244,
+          2.89913,
+          1.7717729,
+          1.2862575,
+          1.5727035,
+          1.1173205,
+          1.4735051,
+          1.5329773,
+          1.0637594,
+          2.0328383,
+          0.8549593,
+          1.233263,
+          1.9429116,
+          1.7426085,
+          1.1928816,
+          1.2990909,
+          3.4804845,
+          1.1483369,
+          0.82016647,
+          2.4731603,
+          1.3759308,
+          1.4286343,
+          1.1893122,
+          1.0759791,
+          3.6784885,
+          1.6885386,
+          1.7106346,
+          2.050166
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>MASE=%{x}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "Seasonal Naive",
+         "notched": true,
+         "offsetgroup": "Seasonal Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          1.7145553,
+          1.3544167,
+          2.3095381,
+          1.8098906,
+          1.8307394,
+          0,
+          1.3096373,
+          1.7109916,
+          1.852141,
+          0.84276956,
+          1.9059796,
+          0.98002315,
+          1.2882712,
+          3.5844228,
+          1.3714103,
+          1.3202732,
+          1.8058187,
+          1.7579752,
+          1.2251116,
+          1.2234967,
+          1.2444086,
+          1.4959503,
+          1.882116,
+          2.6898048,
+          1.4574671,
+          1.1425838,
+          1.4926367,
+          1.4558616,
+          1.9286319,
+          1.7739906,
+          2.1538959,
+          0.9610327,
+          1.3115172,
+          2.0173118,
+          1.4737532,
+          0,
+          0.7874026,
+          0,
+          1.7353317,
+          1.102134,
+          1.7477158,
+          1.7486188,
+          1.2310658,
+          1.9036965,
+          1.224231,
+          1.7169089,
+          2.3592486,
+          0.9404946,
+          1.108985,
+          1.0310267,
+          1.7867357,
+          1.1324563,
+          1.3195217,
+          1.4282197,
+          0,
+          7.300752,
+          1.2031935,
+          0.72668505,
+          1.4143418,
+          2.3315835,
+          1.1547254,
+          1.5492176,
+          2.688156,
+          2.2100701,
+          1.7035667,
+          2.3963847,
+          1.8152696,
+          0.8742443,
+          1.6345637,
+          1.8423308,
+          1.8370812,
+          1.4898417,
+          1.2302006,
+          1.2733743,
+          1.2831849,
+          0.8383917,
+          1.4617414,
+          1.4710169,
+          1.0173,
+          0,
+          1.2209371,
+          1.2160763,
+          2.1888838,
+          1.8471049,
+          1.955696,
+          1.5006967,
+          2.081538,
+          1.4060807,
+          1.4594125,
+          1.0049311,
+          2.819688,
+          1.7650146,
+          1.4515151,
+          1.6889135,
+          1.4750956,
+          2.1078205,
+          1.3811429,
+          1.1252987,
+          2.7839432,
+          1.4371789,
+          1.7260296,
+          1.2187903,
+          1.2654816,
+          1.390372,
+          2.0104098,
+          1.6046541,
+          1.9568183,
+          1.5563737,
+          1.7191355,
+          2.0706584,
+          1.5630431,
+          1.01686,
+          4.5651608,
+          2.0703616,
+          1.0053384,
+          1.3241011,
+          1.1353248,
+          2.6717432,
+          1.8460462,
+          1.2169152,
+          0.5834401,
+          1.1542225,
+          1.6019244,
+          2.89913,
+          1.7717729,
+          1.2862575,
+          1.5727035,
+          1.1173205,
+          1.4735051,
+          1.5329773,
+          1.0637594,
+          2.0328383,
+          0.8549593,
+          1.233263,
+          1.9429116,
+          1.7426085,
+          1.1928816,
+          1.2990909,
+          3.4804845,
+          1.1483369,
+          0.82016647,
+          2.4731603,
+          1.3759308,
+          1.4286343,
+          1.1893122,
+          1.0759791,
+          3.6784885,
+          1.6885386,
+          1.7106346,
+          2.050166
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of MASE in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0,
+          3.2
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "MASE"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_metrics_val_df, \n",
+    "                   x=\"MASE\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=500, \n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"MASE\", ylabel=\"Probability Density\", title=\"Distribution of MASE in the dataset\")\n",
+    "fig.update_layout(xaxis_range=[0,3.2])\n",
+    "# fig.write_image(\"imgs/chapter_4/mase_dist.png\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "05599872-81eb-406c-b096-cece0d153817",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>MAE=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 100,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.03329032,
+          0.08853428,
+          0.043099467,
+          0.16717206,
+          0.0711539,
+          0.010376587,
+          0.06475135,
+          0.107366934,
+          0.17533334,
+          0.07586291,
+          0.13127688,
+          0.03644758,
+          0.057661965,
+          0.30372447,
+          0.06564449,
+          0.038350135,
+          0.19317676,
+          0.07056584,
+          0.041061945,
+          0.12753047,
+          0.026020559,
+          0.047618948,
+          0.10135468,
+          0.06992913,
+          0.13516533,
+          0.06232594,
+          0.059567884,
+          0.07859879,
+          0.03017213,
+          0.09214785,
+          0.15946624,
+          0.024200434,
+          0.01675392,
+          0.06682997,
+          0.078098066,
+          0.026923746,
+          0.020007929,
+          0.018634848,
+          0.10263373,
+          0.07194758,
+          0.082987905,
+          0.06866227,
+          0.067594096,
+          0.10487097,
+          0.081709675,
+          0.094605505,
+          0.12545645,
+          0.07757258,
+          0.07016667,
+          0.048843753,
+          0.051352825,
+          0.05737433,
+          0.06091734,
+          0.1165457,
+          0.00086967193,
+          0.18818213,
+          0.07706822,
+          0.06412903,
+          0.09125726,
+          0.16611426,
+          0.041811153,
+          0.032787476,
+          0.068385415,
+          0.13733293,
+          0.10512231,
+          0.049942203,
+          0.24448386,
+          0.027583374,
+          0.06332056,
+          0.058153898,
+          0.063656725,
+          0.0947379,
+          0.06556653,
+          0.07214441,
+          0.07447245,
+          0.039787635,
+          0.07396842,
+          0.06394882,
+          0.051794093,
+          0.008010093,
+          0.07840457,
+          0.04275546,
+          0.14804637,
+          0.012508036,
+          0.061897997,
+          0.0774207,
+          0.12153159,
+          0.058963712,
+          0.11411694,
+          0.0801718,
+          0.06955612,
+          0.13190725,
+          0.03516024,
+          0.09384409,
+          0.11611156,
+          0.11873723,
+          0.050316535,
+          0.043671373,
+          0.13875404,
+          0.07004301,
+          0.039299056,
+          0.05907428,
+          0.019521592,
+          0.07679637,
+          0.18161762,
+          0.17646505,
+          0.09332594,
+          0.19153965,
+          0.10807593,
+          0.15079166,
+          0.04234341,
+          0.1396087,
+          0.048243962,
+          0.12873387,
+          0.0380625,
+          0.109947264,
+          0.08717339,
+          0.19043683,
+          0.16924478,
+          0.04412567,
+          0.023771506,
+          0.22656049,
+          0.03954906,
+          0.05286895,
+          0.02503998,
+          0.14083056,
+          0.09264851,
+          0.054106858,
+          0.088258065,
+          0.065104835,
+          0.07398925,
+          0.13041331,
+          0.35306185,
+          0.058637097,
+          0.15837635,
+          0.07660753,
+          0.0791418,
+          0.16538374,
+          0.03179902,
+          0.04344019,
+          0.05092742,
+          0.2874973,
+          0.24587232,
+          0.030950941,
+          0.036038306,
+          0.13807394,
+          0.060127012,
+          0.06549866,
+          0.19372915,
+          0.053521346
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>MAE=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.03329032,
+          0.08853428,
+          0.043099467,
+          0.16717206,
+          0.0711539,
+          0.010376587,
+          0.06475135,
+          0.107366934,
+          0.17533334,
+          0.07586291,
+          0.13127688,
+          0.03644758,
+          0.057661965,
+          0.30372447,
+          0.06564449,
+          0.038350135,
+          0.19317676,
+          0.07056584,
+          0.041061945,
+          0.12753047,
+          0.026020559,
+          0.047618948,
+          0.10135468,
+          0.06992913,
+          0.13516533,
+          0.06232594,
+          0.059567884,
+          0.07859879,
+          0.03017213,
+          0.09214785,
+          0.15946624,
+          0.024200434,
+          0.01675392,
+          0.06682997,
+          0.078098066,
+          0.026923746,
+          0.020007929,
+          0.018634848,
+          0.10263373,
+          0.07194758,
+          0.082987905,
+          0.06866227,
+          0.067594096,
+          0.10487097,
+          0.081709675,
+          0.094605505,
+          0.12545645,
+          0.07757258,
+          0.07016667,
+          0.048843753,
+          0.051352825,
+          0.05737433,
+          0.06091734,
+          0.1165457,
+          0.00086967193,
+          0.18818213,
+          0.07706822,
+          0.06412903,
+          0.09125726,
+          0.16611426,
+          0.041811153,
+          0.032787476,
+          0.068385415,
+          0.13733293,
+          0.10512231,
+          0.049942203,
+          0.24448386,
+          0.027583374,
+          0.06332056,
+          0.058153898,
+          0.063656725,
+          0.0947379,
+          0.06556653,
+          0.07214441,
+          0.07447245,
+          0.039787635,
+          0.07396842,
+          0.06394882,
+          0.051794093,
+          0.008010093,
+          0.07840457,
+          0.04275546,
+          0.14804637,
+          0.012508036,
+          0.061897997,
+          0.0774207,
+          0.12153159,
+          0.058963712,
+          0.11411694,
+          0.0801718,
+          0.06955612,
+          0.13190725,
+          0.03516024,
+          0.09384409,
+          0.11611156,
+          0.11873723,
+          0.050316535,
+          0.043671373,
+          0.13875404,
+          0.07004301,
+          0.039299056,
+          0.05907428,
+          0.019521592,
+          0.07679637,
+          0.18161762,
+          0.17646505,
+          0.09332594,
+          0.19153965,
+          0.10807593,
+          0.15079166,
+          0.04234341,
+          0.1396087,
+          0.048243962,
+          0.12873387,
+          0.0380625,
+          0.109947264,
+          0.08717339,
+          0.19043683,
+          0.16924478,
+          0.04412567,
+          0.023771506,
+          0.22656049,
+          0.03954906,
+          0.05286895,
+          0.02503998,
+          0.14083056,
+          0.09264851,
+          0.054106858,
+          0.088258065,
+          0.065104835,
+          0.07398925,
+          0.13041331,
+          0.35306185,
+          0.058637097,
+          0.15837635,
+          0.07660753,
+          0.0791418,
+          0.16538374,
+          0.03179902,
+          0.04344019,
+          0.05092742,
+          0.2874973,
+          0.24587232,
+          0.030950941,
+          0.036038306,
+          0.13807394,
+          0.060127012,
+          0.06549866,
+          0.19372915,
+          0.053521346
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>MAE=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "Seasonal Naive",
+         "nbinsx": 100,
+         "offsetgroup": "Seasonal Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.059911963,
+          0.10197446,
+          0.089192204,
+          0.15555309,
+          0.120749995,
+          0,
+          0.075658605,
+          0.13581048,
+          0.23766196,
+          0.08882997,
+          0.22642608,
+          0.037919354,
+          0.07332259,
+          0.6364859,
+          0.07985014,
+          0.040171374,
+          0.27476075,
+          0.10197652,
+          0.05643094,
+          0.14255723,
+          0.026644532,
+          0.058940858,
+          0.17605734,
+          0.12947474,
+          0.19166128,
+          0.0736418,
+          0.084257394,
+          0.10671708,
+          0.047866493,
+          0.14915122,
+          0.33030438,
+          0.027988434,
+          0.02146684,
+          0.14376277,
+          0.11156875,
+          0,
+          0.016906777,
+          0,
+          0.14058131,
+          0.09043144,
+          0.12440995,
+          0.10918328,
+          0.09320561,
+          0.15679167,
+          0.11541936,
+          0.12227352,
+          0.23786762,
+          0.08266532,
+          0.07659274,
+          0.066115685,
+          0.057696905,
+          0.058243953,
+          0.06892876,
+          0.13976948,
+          0,
+          0.3264207,
+          0.10119797,
+          0.04240457,
+          0.10952081,
+          0.3069812,
+          0.057208333,
+          0.04905192,
+          0.10649471,
+          0.21842329,
+          0.14714013,
+          0.10036223,
+          0.47646037,
+          0.02889484,
+          0.10726613,
+          0.084573254,
+          0.11243324,
+          0.1319375,
+          0.12487702,
+          0.11660102,
+          0.091092974,
+          0.047315188,
+          0.09481921,
+          0.091046415,
+          0.048395135,
+          0,
+          0.089536965,
+          0.051522877,
+          0.26445833,
+          0.016001914,
+          0.087532155,
+          0.118056454,
+          0.21044825,
+          0.08701679,
+          0.1697715,
+          0.07534163,
+          0.1576859,
+          0.217084,
+          0.05361531,
+          0.15805511,
+          0.15739517,
+          0.21049194,
+          0.0702715,
+          0.055629034,
+          0.27443683,
+          0.0756082,
+          0.062307123,
+          0.073984794,
+          0.019359335,
+          0.10170027,
+          0.29036865,
+          0.22876008,
+          0.19948119,
+          0.27214316,
+          0.17464653,
+          0.22917812,
+          0.054291,
+          0.1663148,
+          0.17259523,
+          0.20950338,
+          0.045413304,
+          0.117318,
+          0.09165658,
+          0.40082997,
+          0.27187562,
+          0.071670696,
+          0.07628629,
+          0.22839181,
+          0.05282191,
+          0.10271976,
+          0.049731564,
+          0.17471728,
+          0.1375316,
+          0.07020296,
+          0.105838716,
+          0.08086694,
+          0.07960484,
+          0.23355915,
+          0.23021169,
+          0.07464516,
+          0.29799598,
+          0.1314422,
+          0.09554032,
+          0.20122918,
+          0.08013693,
+          0.049732525,
+          0.043402553,
+          0.49852416,
+          0.32571843,
+          0.04718884,
+          0.041081317,
+          0.09619959,
+          0.20121707,
+          0.09540121,
+          0.22091466,
+          0.110623024
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>MAE=%{x}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "Seasonal Naive",
+         "notched": true,
+         "offsetgroup": "Seasonal Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.059911963,
+          0.10197446,
+          0.089192204,
+          0.15555309,
+          0.120749995,
+          0,
+          0.075658605,
+          0.13581048,
+          0.23766196,
+          0.08882997,
+          0.22642608,
+          0.037919354,
+          0.07332259,
+          0.6364859,
+          0.07985014,
+          0.040171374,
+          0.27476075,
+          0.10197652,
+          0.05643094,
+          0.14255723,
+          0.026644532,
+          0.058940858,
+          0.17605734,
+          0.12947474,
+          0.19166128,
+          0.0736418,
+          0.084257394,
+          0.10671708,
+          0.047866493,
+          0.14915122,
+          0.33030438,
+          0.027988434,
+          0.02146684,
+          0.14376277,
+          0.11156875,
+          0,
+          0.016906777,
+          0,
+          0.14058131,
+          0.09043144,
+          0.12440995,
+          0.10918328,
+          0.09320561,
+          0.15679167,
+          0.11541936,
+          0.12227352,
+          0.23786762,
+          0.08266532,
+          0.07659274,
+          0.066115685,
+          0.057696905,
+          0.058243953,
+          0.06892876,
+          0.13976948,
+          0,
+          0.3264207,
+          0.10119797,
+          0.04240457,
+          0.10952081,
+          0.3069812,
+          0.057208333,
+          0.04905192,
+          0.10649471,
+          0.21842329,
+          0.14714013,
+          0.10036223,
+          0.47646037,
+          0.02889484,
+          0.10726613,
+          0.084573254,
+          0.11243324,
+          0.1319375,
+          0.12487702,
+          0.11660102,
+          0.091092974,
+          0.047315188,
+          0.09481921,
+          0.091046415,
+          0.048395135,
+          0,
+          0.089536965,
+          0.051522877,
+          0.26445833,
+          0.016001914,
+          0.087532155,
+          0.118056454,
+          0.21044825,
+          0.08701679,
+          0.1697715,
+          0.07534163,
+          0.1576859,
+          0.217084,
+          0.05361531,
+          0.15805511,
+          0.15739517,
+          0.21049194,
+          0.0702715,
+          0.055629034,
+          0.27443683,
+          0.0756082,
+          0.062307123,
+          0.073984794,
+          0.019359335,
+          0.10170027,
+          0.29036865,
+          0.22876008,
+          0.19948119,
+          0.27214316,
+          0.17464653,
+          0.22917812,
+          0.054291,
+          0.1663148,
+          0.17259523,
+          0.20950338,
+          0.045413304,
+          0.117318,
+          0.09165658,
+          0.40082997,
+          0.27187562,
+          0.071670696,
+          0.07628629,
+          0.22839181,
+          0.05282191,
+          0.10271976,
+          0.049731564,
+          0.17471728,
+          0.1375316,
+          0.07020296,
+          0.105838716,
+          0.08086694,
+          0.07960484,
+          0.23355915,
+          0.23021169,
+          0.07464516,
+          0.29799598,
+          0.1314422,
+          0.09554032,
+          0.20122918,
+          0.08013693,
+          0.049732525,
+          0.043402553,
+          0.49852416,
+          0.32571843,
+          0.04718884,
+          0.041081317,
+          0.09619959,
+          0.20121707,
+          0.09540121,
+          0.22091466,
+          0.110623024
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of MAE in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0,
+          0.5
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "MAE"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_metrics_val_df, \n",
+    "                   x=\"MAE\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=100, \n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"MAE\", ylabel=\"Probability Density\", title=\"Distribution of MAE in the dataset\")\n",
+    "# fig.write_image(\"imgs/chapter_4/mae_dist.png\")\n",
+    "fig.update_layout(xaxis_range=[0,0.5])\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "9e89266e-ab40-4f44-9461-ec0c755c6a61",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>MSE=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 500,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.0035607233,
+          0.04069073,
+          0.011811284,
+          0.04897582,
+          0.022801207,
+          0.00020271435,
+          0.012544806,
+          0.03783492,
+          0.10495549,
+          0.014169418,
+          0.0669624,
+          0.0029195163,
+          0.008815694,
+          0.21765547,
+          0.01327216,
+          0.0062670745,
+          0.12039935,
+          0.020466382,
+          0.005993567,
+          0.043798048,
+          0.006497233,
+          0.0086294,
+          0.037490476,
+          0.019821933,
+          0.0553168,
+          0.014187599,
+          0.014851648,
+          0.02502731,
+          0.004357532,
+          0.025558036,
+          0.07122919,
+          0.0010413316,
+          0.0007914824,
+          0.021497939,
+          0.02202874,
+          0.003033771,
+          0.0010981078,
+          0.0006378834,
+          0.054390427,
+          0.035274833,
+          0.030470997,
+          0.024602264,
+          0.015863046,
+          0.039041247,
+          0.044434484,
+          0.038624913,
+          0.048996057,
+          0.019717868,
+          0.021076106,
+          0.012964825,
+          0.012752659,
+          0.007425994,
+          0.018035278,
+          0.03449422,
+          0.0000030696535,
+          0.14555971,
+          0.02474248,
+          0.016344909,
+          0.03131132,
+          0.06987433,
+          0.009218098,
+          0.0030183075,
+          0.022860311,
+          0.060438637,
+          0.048273087,
+          0.009350684,
+          0.15904589,
+          0.0025926626,
+          0.011179008,
+          0.010376729,
+          0.016627437,
+          0.030307738,
+          0.0209422,
+          0.023078557,
+          0.02018255,
+          0.005654676,
+          0.019623213,
+          0.008203073,
+          0.008171433,
+          0.00011082899,
+          0.054613635,
+          0.0049262606,
+          0.080612585,
+          0.0004972591,
+          0.015402722,
+          0.022620058,
+          0.042124163,
+          0.016494485,
+          0.038581327,
+          0.021164017,
+          0.026466193,
+          0.05152178,
+          0.0045540626,
+          0.021385793,
+          0.058046084,
+          0.046954997,
+          0.019893225,
+          0.00647933,
+          0.11418571,
+          0.01872963,
+          0.0049635842,
+          0.01607202,
+          0.0009528149,
+          0.020503758,
+          0.08044191,
+          0.11832366,
+          0.0356428,
+          0.10163158,
+          0.05116865,
+          0.061466105,
+          0.011825725,
+          0.12775147,
+          0.014337142,
+          0.051278464,
+          0.0058741216,
+          0.060406655,
+          0.025542539,
+          0.34219232,
+          0.0844051,
+          0.0152062215,
+          0.0043112785,
+          0.3086315,
+          0.0053811325,
+          0.01501823,
+          0.0024470626,
+          0.077254966,
+          0.02874841,
+          0.027515464,
+          0.016971229,
+          0.01796776,
+          0.018373825,
+          0.046363983,
+          0.7411547,
+          0.0088813,
+          0.11550973,
+          0.024517111,
+          0.03405631,
+          0.098613076,
+          0.0071155755,
+          0.005940339,
+          0.00799679,
+          0.22541456,
+          0.13896434,
+          0.0029609348,
+          0.028768681,
+          0.15127309,
+          0.020819152,
+          0.017700238,
+          0.2616266,
+          0.019192643
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>MSE=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.0035607233,
+          0.04069073,
+          0.011811284,
+          0.04897582,
+          0.022801207,
+          0.00020271435,
+          0.012544806,
+          0.03783492,
+          0.10495549,
+          0.014169418,
+          0.0669624,
+          0.0029195163,
+          0.008815694,
+          0.21765547,
+          0.01327216,
+          0.0062670745,
+          0.12039935,
+          0.020466382,
+          0.005993567,
+          0.043798048,
+          0.006497233,
+          0.0086294,
+          0.037490476,
+          0.019821933,
+          0.0553168,
+          0.014187599,
+          0.014851648,
+          0.02502731,
+          0.004357532,
+          0.025558036,
+          0.07122919,
+          0.0010413316,
+          0.0007914824,
+          0.021497939,
+          0.02202874,
+          0.003033771,
+          0.0010981078,
+          0.0006378834,
+          0.054390427,
+          0.035274833,
+          0.030470997,
+          0.024602264,
+          0.015863046,
+          0.039041247,
+          0.044434484,
+          0.038624913,
+          0.048996057,
+          0.019717868,
+          0.021076106,
+          0.012964825,
+          0.012752659,
+          0.007425994,
+          0.018035278,
+          0.03449422,
+          0.0000030696535,
+          0.14555971,
+          0.02474248,
+          0.016344909,
+          0.03131132,
+          0.06987433,
+          0.009218098,
+          0.0030183075,
+          0.022860311,
+          0.060438637,
+          0.048273087,
+          0.009350684,
+          0.15904589,
+          0.0025926626,
+          0.011179008,
+          0.010376729,
+          0.016627437,
+          0.030307738,
+          0.0209422,
+          0.023078557,
+          0.02018255,
+          0.005654676,
+          0.019623213,
+          0.008203073,
+          0.008171433,
+          0.00011082899,
+          0.054613635,
+          0.0049262606,
+          0.080612585,
+          0.0004972591,
+          0.015402722,
+          0.022620058,
+          0.042124163,
+          0.016494485,
+          0.038581327,
+          0.021164017,
+          0.026466193,
+          0.05152178,
+          0.0045540626,
+          0.021385793,
+          0.058046084,
+          0.046954997,
+          0.019893225,
+          0.00647933,
+          0.11418571,
+          0.01872963,
+          0.0049635842,
+          0.01607202,
+          0.0009528149,
+          0.020503758,
+          0.08044191,
+          0.11832366,
+          0.0356428,
+          0.10163158,
+          0.05116865,
+          0.061466105,
+          0.011825725,
+          0.12775147,
+          0.014337142,
+          0.051278464,
+          0.0058741216,
+          0.060406655,
+          0.025542539,
+          0.34219232,
+          0.0844051,
+          0.0152062215,
+          0.0043112785,
+          0.3086315,
+          0.0053811325,
+          0.01501823,
+          0.0024470626,
+          0.077254966,
+          0.02874841,
+          0.027515464,
+          0.016971229,
+          0.01796776,
+          0.018373825,
+          0.046363983,
+          0.7411547,
+          0.0088813,
+          0.11550973,
+          0.024517111,
+          0.03405631,
+          0.098613076,
+          0.0071155755,
+          0.005940339,
+          0.00799679,
+          0.22541456,
+          0.13896434,
+          0.0029609348,
+          0.028768681,
+          0.15127309,
+          0.020819152,
+          0.017700238,
+          0.2616266,
+          0.019192643
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>MSE=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "Seasonal Naive",
+         "nbinsx": 500,
+         "offsetgroup": "Seasonal Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          0.008075674,
+          0.053449176,
+          0.03299938,
+          0.047774807,
+          0.051586844,
+          0,
+          0.016467862,
+          0.053204022,
+          0.17094845,
+          0.021453707,
+          0.15900505,
+          0.0030785818,
+          0.013718274,
+          0.72075284,
+          0.01902377,
+          0.0069778864,
+          0.22420774,
+          0.03983427,
+          0.0076335818,
+          0.05258521,
+          0.0057212235,
+          0.011252304,
+          0.07659288,
+          0.058157783,
+          0.07911559,
+          0.024856342,
+          0.025025532,
+          0.038363703,
+          0.00854971,
+          0.058899317,
+          0.22799343,
+          0.0014423087,
+          0.0013924738,
+          0.07831662,
+          0.038123358,
+          0,
+          0.0008048219,
+          0,
+          0.0703609,
+          0.043430094,
+          0.06805136,
+          0.047707908,
+          0.029072328,
+          0.07526738,
+          0.07631444,
+          0.052320674,
+          0.1338116,
+          0.023444494,
+          0.020465268,
+          0.019013697,
+          0.016362593,
+          0.0090449415,
+          0.023435023,
+          0.04502012,
+          0,
+          0.33276653,
+          0.04189671,
+          0.007556936,
+          0.044608757,
+          0.1982332,
+          0.015942676,
+          0.00468377,
+          0.042438734,
+          0.11821823,
+          0.07921952,
+          0.02561479,
+          0.45818278,
+          0.0030650196,
+          0.026594467,
+          0.020752959,
+          0.036294457,
+          0.047156252,
+          0.05344033,
+          0.044258904,
+          0.024892658,
+          0.009557569,
+          0.031454466,
+          0.017941423,
+          0.0065297536,
+          0,
+          0.052114733,
+          0.0067522693,
+          0.20144969,
+          0.00073401484,
+          0.030923266,
+          0.034572225,
+          0.1243024,
+          0.031648446,
+          0.07441648,
+          0.018367575,
+          0.079687394,
+          0.13652264,
+          0.00962598,
+          0.057575386,
+          0.085942015,
+          0.12669232,
+          0.028348444,
+          0.0104820635,
+          0.28618503,
+          0.021408716,
+          0.010768073,
+          0.022825103,
+          0.0010340415,
+          0.033652347,
+          0.17186774,
+          0.16266762,
+          0.1224147,
+          0.16844065,
+          0.10356175,
+          0.14090213,
+          0.014734855,
+          0.15629202,
+          0.07187042,
+          0.108774215,
+          0.0078585595,
+          0.07504612,
+          0.027966058,
+          0.8495874,
+          0.19416012,
+          0.02482382,
+          0.029557489,
+          0.31100512,
+          0.008343439,
+          0.030121835,
+          0.0058107222,
+          0.10676911,
+          0.048196316,
+          0.03240477,
+          0.024005445,
+          0.026350796,
+          0.021153115,
+          0.12154029,
+          0.16668808,
+          0.01951862,
+          0.29549596,
+          0.04930469,
+          0.042170122,
+          0.13470441,
+          0.018145008,
+          0.010023363,
+          0.0076531377,
+          0.562285,
+          0.22032838,
+          0.005246694,
+          0.027854525,
+          0.04842709,
+          0.13589002,
+          0.028323488,
+          0.29094306,
+          0.051093183
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>MSE=%{x}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "Seasonal Naive",
+         "notched": true,
+         "offsetgroup": "Seasonal Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.008075674,
+          0.053449176,
+          0.03299938,
+          0.047774807,
+          0.051586844,
+          0,
+          0.016467862,
+          0.053204022,
+          0.17094845,
+          0.021453707,
+          0.15900505,
+          0.0030785818,
+          0.013718274,
+          0.72075284,
+          0.01902377,
+          0.0069778864,
+          0.22420774,
+          0.03983427,
+          0.0076335818,
+          0.05258521,
+          0.0057212235,
+          0.011252304,
+          0.07659288,
+          0.058157783,
+          0.07911559,
+          0.024856342,
+          0.025025532,
+          0.038363703,
+          0.00854971,
+          0.058899317,
+          0.22799343,
+          0.0014423087,
+          0.0013924738,
+          0.07831662,
+          0.038123358,
+          0,
+          0.0008048219,
+          0,
+          0.0703609,
+          0.043430094,
+          0.06805136,
+          0.047707908,
+          0.029072328,
+          0.07526738,
+          0.07631444,
+          0.052320674,
+          0.1338116,
+          0.023444494,
+          0.020465268,
+          0.019013697,
+          0.016362593,
+          0.0090449415,
+          0.023435023,
+          0.04502012,
+          0,
+          0.33276653,
+          0.04189671,
+          0.007556936,
+          0.044608757,
+          0.1982332,
+          0.015942676,
+          0.00468377,
+          0.042438734,
+          0.11821823,
+          0.07921952,
+          0.02561479,
+          0.45818278,
+          0.0030650196,
+          0.026594467,
+          0.020752959,
+          0.036294457,
+          0.047156252,
+          0.05344033,
+          0.044258904,
+          0.024892658,
+          0.009557569,
+          0.031454466,
+          0.017941423,
+          0.0065297536,
+          0,
+          0.052114733,
+          0.0067522693,
+          0.20144969,
+          0.00073401484,
+          0.030923266,
+          0.034572225,
+          0.1243024,
+          0.031648446,
+          0.07441648,
+          0.018367575,
+          0.079687394,
+          0.13652264,
+          0.00962598,
+          0.057575386,
+          0.085942015,
+          0.12669232,
+          0.028348444,
+          0.0104820635,
+          0.28618503,
+          0.021408716,
+          0.010768073,
+          0.022825103,
+          0.0010340415,
+          0.033652347,
+          0.17186774,
+          0.16266762,
+          0.1224147,
+          0.16844065,
+          0.10356175,
+          0.14090213,
+          0.014734855,
+          0.15629202,
+          0.07187042,
+          0.108774215,
+          0.0078585595,
+          0.07504612,
+          0.027966058,
+          0.8495874,
+          0.19416012,
+          0.02482382,
+          0.029557489,
+          0.31100512,
+          0.008343439,
+          0.030121835,
+          0.0058107222,
+          0.10676911,
+          0.048196316,
+          0.03240477,
+          0.024005445,
+          0.026350796,
+          0.021153115,
+          0.12154029,
+          0.16668808,
+          0.01951862,
+          0.29549596,
+          0.04930469,
+          0.042170122,
+          0.13470441,
+          0.018145008,
+          0.010023363,
+          0.0076531377,
+          0.562285,
+          0.22032838,
+          0.005246694,
+          0.027854525,
+          0.04842709,
+          0.13589002,
+          0.028323488,
+          0.29094306,
+          0.051093183
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of MSE in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0,
+          0.6
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "MSE"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_metrics_val_df, \n",
+    "                   x=\"MSE\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=500, \n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"MSE\", ylabel=\"Probability Density\", title=\"Distribution of MSE in the dataset\")\n",
+    "fig.update_layout(xaxis_range=[0,0.6])\n",
+    "# fig.write_image(\"imgs/chapter_4/mse_dist.png\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "2695707d-1e83-4289-9aea-859bbf83586c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Naive<br>Forecast Bias=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Naive",
+         "nbinsx": 250,
+         "offsetgroup": "Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          -0.05910452455282211,
+          -0.07675477536395192,
+          -0.05743643851019442,
+          0.008481548866257071,
+          -0.07103384705260396,
+          0.00010347722536607762,
+          -0.2538697328418493,
+          -0.028858613222837448,
+          0.026067355065606534,
+          -0.04844636714551598,
+          -0.011800731590483338,
+          -0.0042729167034849524,
+          -0.06944039487279952,
+          0.1114289159886539,
+          0.06037737475708127,
+          -0.036882152198813856,
+          0.061914039542898536,
+          -0.052336108637973666,
+          0.008020676614250988,
+          -0.04314935940783471,
+          -0.0011815541256510187,
+          0.020711030811071396,
+          0.031295273220166564,
+          -0.0026782528948388062,
+          0.0026873882234212942,
+          -0.01420238841092214,
+          0.020509010937530547,
+          -0.028370381915010512,
+          -0.0006312924597295932,
+          0.03281068056821823,
+          -0.02200961025664583,
+          -0.00261193035839824,
+          0.005908564344281331,
+          -0.012785960279870778,
+          -0.023782394418958575,
+          -0.0021371501134126447,
+          -0.046428205678239465,
+          -0.02429655723972246,
+          0.0327268528053537,
+          -0.016247261373791844,
+          -0.02630439994391054,
+          -0.031749074696563184,
+          0.031944928923621774,
+          0.0011534541044966318,
+          -0.030026596505194902,
+          -0.011130499478895217,
+          -0.015043288294691592,
+          -0.01484216918470338,
+          -0.035402190405875444,
+          0.034630094887688756,
+          0.028021816979162395,
+          0.06518964655697346,
+          0.44745393097400665,
+          -0.03989633114542812,
+          -0.00968963504419662,
+          -0.010281029244652018,
+          0.006751147884642705,
+          0.010197298979619518,
+          0.039951520739123225,
+          0.027514860266819596,
+          -0.015977789007592946,
+          0.030705277458764613,
+          -0.09189060656353831,
+          -0.004634345532394946,
+          0.011587900371523574,
+          0,
+          0.10194776114076376,
+          -0.06329329335130751,
+          -0.043792149517685175,
+          -0.012470337969716638,
+          -0.05785351968370378,
+          -0.013626183499582112,
+          -0.005221092942520045,
+          0.02951800706796348,
+          -0.027736471383832395,
+          -0.01417459425283596,
+          0.013641758414451033,
+          -0.06119165336713195,
+          0.019822137255687267,
+          0.012854300439357758,
+          -0.08408678113482893,
+          -0.046486721839755774,
+          -0.020851529552601278,
+          -0.07027449319139123,
+          -0.10405451757833362,
+          0.09047914063557982,
+          -0.024177438172046095,
+          -0.026432008598931134,
+          -0.0010603558621369302,
+          0.006765399302821606,
+          -0.08002928225323558,
+          -0.014810048742219806,
+          -0.01571139000589028,
+          -0.10372224496677518,
+          0.021696233307011425,
+          0.006990645488258451,
+          -0.002293852412549313,
+          -0.006390854832716286,
+          -0.05721557536162436,
+          -0.007912915316410363,
+          0.004678883124142885,
+          0.1290750689804554,
+          -0.00968926542554982,
+          -0.03678791399579495,
+          0.010933099838439375,
+          0.04932334995828569,
+          -0.17860432853922248,
+          -0.05269627436064184,
+          0.02288606483489275,
+          0.022251180780585855,
+          0.015428334882017225,
+          -0.02647564106155187,
+          -0.0019266730305389501,
+          0.07379324524663389,
+          -0.0660416204482317,
+          -0.013813174155075103,
+          -0.010389120143372566,
+          0.0006721170848322799,
+          0.0906574772670865,
+          -0.003815530362771824,
+          0.011906869622180238,
+          -0.0054176060075405985,
+          -0.03748085582628846,
+          0.34929090179502964,
+          -0.006833543739048764,
+          0.04088954592589289,
+          0.05518279504030943,
+          0.010292522347299382,
+          -0.003031440428458154,
+          0.0080435311247129,
+          0.08341840584762394,
+          0.004990497473045252,
+          -0.00871102383825928,
+          -0.006094657874200493,
+          -0.012397932005114853,
+          -0.07220220286399126,
+          -0.0685753591824323,
+          -0.022209080634638667,
+          0.03185320820193738,
+          -0.04559223016258329,
+          -0.010768270294647664,
+          0.027751066954806447,
+          0.032389850821346045,
+          0.02366408152738586,
+          0.0008595871804573108,
+          0.024666287936270237,
+          0.014112070493865758,
+          -0.1258592470549047,
+          -0.0770724262110889,
+          -0.0046679273509653285
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Naive<br>Forecast Bias=%{x}<extra></extra>",
+         "legendgroup": "Naive",
+         "marker": {
+          "color": "#636efa"
+         },
+         "name": "Naive",
+         "notched": true,
+         "offsetgroup": "Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          -0.05910452455282211,
+          -0.07675477536395192,
+          -0.05743643851019442,
+          0.008481548866257071,
+          -0.07103384705260396,
+          0.00010347722536607762,
+          -0.2538697328418493,
+          -0.028858613222837448,
+          0.026067355065606534,
+          -0.04844636714551598,
+          -0.011800731590483338,
+          -0.0042729167034849524,
+          -0.06944039487279952,
+          0.1114289159886539,
+          0.06037737475708127,
+          -0.036882152198813856,
+          0.061914039542898536,
+          -0.052336108637973666,
+          0.008020676614250988,
+          -0.04314935940783471,
+          -0.0011815541256510187,
+          0.020711030811071396,
+          0.031295273220166564,
+          -0.0026782528948388062,
+          0.0026873882234212942,
+          -0.01420238841092214,
+          0.020509010937530547,
+          -0.028370381915010512,
+          -0.0006312924597295932,
+          0.03281068056821823,
+          -0.02200961025664583,
+          -0.00261193035839824,
+          0.005908564344281331,
+          -0.012785960279870778,
+          -0.023782394418958575,
+          -0.0021371501134126447,
+          -0.046428205678239465,
+          -0.02429655723972246,
+          0.0327268528053537,
+          -0.016247261373791844,
+          -0.02630439994391054,
+          -0.031749074696563184,
+          0.031944928923621774,
+          0.0011534541044966318,
+          -0.030026596505194902,
+          -0.011130499478895217,
+          -0.015043288294691592,
+          -0.01484216918470338,
+          -0.035402190405875444,
+          0.034630094887688756,
+          0.028021816979162395,
+          0.06518964655697346,
+          0.44745393097400665,
+          -0.03989633114542812,
+          -0.00968963504419662,
+          -0.010281029244652018,
+          0.006751147884642705,
+          0.010197298979619518,
+          0.039951520739123225,
+          0.027514860266819596,
+          -0.015977789007592946,
+          0.030705277458764613,
+          -0.09189060656353831,
+          -0.004634345532394946,
+          0.011587900371523574,
+          0,
+          0.10194776114076376,
+          -0.06329329335130751,
+          -0.043792149517685175,
+          -0.012470337969716638,
+          -0.05785351968370378,
+          -0.013626183499582112,
+          -0.005221092942520045,
+          0.02951800706796348,
+          -0.027736471383832395,
+          -0.01417459425283596,
+          0.013641758414451033,
+          -0.06119165336713195,
+          0.019822137255687267,
+          0.012854300439357758,
+          -0.08408678113482893,
+          -0.046486721839755774,
+          -0.020851529552601278,
+          -0.07027449319139123,
+          -0.10405451757833362,
+          0.09047914063557982,
+          -0.024177438172046095,
+          -0.026432008598931134,
+          -0.0010603558621369302,
+          0.006765399302821606,
+          -0.08002928225323558,
+          -0.014810048742219806,
+          -0.01571139000589028,
+          -0.10372224496677518,
+          0.021696233307011425,
+          0.006990645488258451,
+          -0.002293852412549313,
+          -0.006390854832716286,
+          -0.05721557536162436,
+          -0.007912915316410363,
+          0.004678883124142885,
+          0.1290750689804554,
+          -0.00968926542554982,
+          -0.03678791399579495,
+          0.010933099838439375,
+          0.04932334995828569,
+          -0.17860432853922248,
+          -0.05269627436064184,
+          0.02288606483489275,
+          0.022251180780585855,
+          0.015428334882017225,
+          -0.02647564106155187,
+          -0.0019266730305389501,
+          0.07379324524663389,
+          -0.0660416204482317,
+          -0.013813174155075103,
+          -0.010389120143372566,
+          0.0006721170848322799,
+          0.0906574772670865,
+          -0.003815530362771824,
+          0.011906869622180238,
+          -0.0054176060075405985,
+          -0.03748085582628846,
+          0.34929090179502964,
+          -0.006833543739048764,
+          0.04088954592589289,
+          0.05518279504030943,
+          0.010292522347299382,
+          -0.003031440428458154,
+          0.0080435311247129,
+          0.08341840584762394,
+          0.004990497473045252,
+          -0.00871102383825928,
+          -0.006094657874200493,
+          -0.012397932005114853,
+          -0.07220220286399126,
+          -0.0685753591824323,
+          -0.022209080634638667,
+          0.03185320820193738,
+          -0.04559223016258329,
+          -0.010768270294647664,
+          0.027751066954806447,
+          0.032389850821346045,
+          0.02366408152738586,
+          0.0008595871804573108,
+          0.024666287936270237,
+          0.014112070493865758,
+          -0.1258592470549047,
+          -0.0770724262110889,
+          -0.0046679273509653285
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        },
+        {
+         "alignmentgroup": "True",
+         "bingroup": "x",
+         "histnorm": "probability density",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>Forecast Bias=%{x}<br>probability density=%{y}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B",
+          "opacity": 0.5,
+          "pattern": {
+           "shape": "/"
+          }
+         },
+         "name": "Seasonal Naive",
+         "nbinsx": 250,
+         "offsetgroup": "Seasonal Naive",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "histogram",
+         "x": [
+          -2.8300154954195023,
+          0.3600150113925338,
+          -17.725856602191925,
+          -2.2808190435171127,
+          -2.204521931707859,
+          0,
+          -2.2373782470822334,
+          -6.61289170384407,
+          4.796077683568001,
+          1.2487220577895641,
+          -0.5492649506777525,
+          -0.9665012359619141,
+          -3.8840949535369873,
+          15.5678391456604,
+          3.160535916686058,
+          -0.629558227956295,
+          -7.678401470184326,
+          2.412293292582035,
+          -0.1862912205979228,
+          1.92363690584898,
+          2.265102230012417,
+          -4.9081481993198395,
+          -1.4730392955243587,
+          13.069908320903778,
+          1.114534866064787,
+          -3.6080192774534225,
+          12.67092376947403,
+          9.045462310314178,
+          0.33348503056913614,
+          1.7924442887306213,
+          -2.31081023812294,
+          1.6396358609199524,
+          5.834260955452919,
+          -5.933932214975357,
+          0.6557365879416466,
+          0,
+          -1.2326454743742943,
+          0,
+          -1.8950076773762703,
+          -2.660992369055748,
+          7.211918383836746,
+          4.115981608629227,
+          -1.4215543866157532,
+          -0.9919353760778904,
+          5.747478827834129,
+          8.50038006901741,
+          -7.670404016971588,
+          -3.0446965247392654,
+          0.8239313960075378,
+          -8.59852284193039,
+          -2.244027517735958,
+          2.7090350165963173,
+          17.322666943073273,
+          1.7153369262814522,
+          0,
+          27.221742272377014,
+          -0.17113216454163194,
+          -1.4101999811828136,
+          -2.4531414732337,
+          10.722479969263077,
+          1.2629260309040546,
+          -1.994762383401394,
+          -6.601770222187042,
+          -5.946362763643265,
+          -2.074546180665493,
+          2.960849553346634,
+          0.7748194504529238,
+          1.2963786721229553,
+          1.8688419833779335,
+          -7.6056107878685,
+          3.294576331973076,
+          -7.1007296442985535,
+          -6.323961913585663,
+          -3.0103983357548714,
+          0.1409937278367579,
+          -1.9777238368988037,
+          -3.283429890871048,
+          -0.8201633580029011,
+          -3.7727858871221542,
+          0,
+          2.232632413506508,
+          7.083704322576523,
+          2.354704774916172,
+          -2.0350223407149315,
+          -3.0145542696118355,
+          -2.8487976640462875,
+          -16.977503895759583,
+          4.476479813456535,
+          -6.949497759342194,
+          1.4966619201004505,
+          3.739132732152939,
+          -25.95657706260681,
+          -3.187382221221924,
+          -0.5704784765839577,
+          0.3707245457917452,
+          -8.255671709775925,
+          15.765897929668427,
+          -5.173716694116592,
+          -4.539374262094498,
+          0.03926255740225315,
+          -0.01611439074622467,
+          -1.379693578928709,
+          2.030264213681221,
+          1.4942270703613758,
+          4.593566060066223,
+          -3.95367331802845,
+          -22.77061492204666,
+          5.6529700756073,
+          -1.0423325933516026,
+          -5.0238750874996185,
+          4.6988919377326965,
+          -2.6057062670588493,
+          -0.7200319785624743,
+          5.382653325796127,
+          0.6544105708599091,
+          1.1035723611712456,
+          5.077438056468964,
+          14.73010778427124,
+          -2.7364419773221016,
+          -1.082111056894064,
+          27.203083038330078,
+          16.853955388069153,
+          -8.552335947751999,
+          14.096322655677795,
+          -3.2765086740255356,
+          12.993219494819641,
+          -5.702397972345352,
+          -32.03296661376953,
+          2.665330283343792,
+          0.30319206416606903,
+          -3.249441459774971,
+          -11.265448480844498,
+          2.9967404901981354,
+          2.6826946064829826,
+          28.039467334747314,
+          -20.852795243263245,
+          -4.159173741936684,
+          -0.6737133953720331,
+          -7.485503703355789,
+          -0.8903210982680321,
+          13.293696939945221,
+          4.764354974031448,
+          -0.008843891555443406,
+          6.243377551436424,
+          0.3104881616309285,
+          -2.5746403262019157,
+          13.892289996147156,
+          -0.35134966019541025,
+          -6.771973520517349,
+          -0.45568710193037987
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Algorithm=Seasonal Naive<br>Forecast Bias=%{x}<extra></extra>",
+         "legendgroup": "Seasonal Naive",
+         "marker": {
+          "color": "#EF553B"
+         },
+         "name": "Seasonal Naive",
+         "notched": true,
+         "offsetgroup": "Seasonal Naive",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          -2.8300154954195023,
+          0.3600150113925338,
+          -17.725856602191925,
+          -2.2808190435171127,
+          -2.204521931707859,
+          0,
+          -2.2373782470822334,
+          -6.61289170384407,
+          4.796077683568001,
+          1.2487220577895641,
+          -0.5492649506777525,
+          -0.9665012359619141,
+          -3.8840949535369873,
+          15.5678391456604,
+          3.160535916686058,
+          -0.629558227956295,
+          -7.678401470184326,
+          2.412293292582035,
+          -0.1862912205979228,
+          1.92363690584898,
+          2.265102230012417,
+          -4.9081481993198395,
+          -1.4730392955243587,
+          13.069908320903778,
+          1.114534866064787,
+          -3.6080192774534225,
+          12.67092376947403,
+          9.045462310314178,
+          0.33348503056913614,
+          1.7924442887306213,
+          -2.31081023812294,
+          1.6396358609199524,
+          5.834260955452919,
+          -5.933932214975357,
+          0.6557365879416466,
+          0,
+          -1.2326454743742943,
+          0,
+          -1.8950076773762703,
+          -2.660992369055748,
+          7.211918383836746,
+          4.115981608629227,
+          -1.4215543866157532,
+          -0.9919353760778904,
+          5.747478827834129,
+          8.50038006901741,
+          -7.670404016971588,
+          -3.0446965247392654,
+          0.8239313960075378,
+          -8.59852284193039,
+          -2.244027517735958,
+          2.7090350165963173,
+          17.322666943073273,
+          1.7153369262814522,
+          0,
+          27.221742272377014,
+          -0.17113216454163194,
+          -1.4101999811828136,
+          -2.4531414732337,
+          10.722479969263077,
+          1.2629260309040546,
+          -1.994762383401394,
+          -6.601770222187042,
+          -5.946362763643265,
+          -2.074546180665493,
+          2.960849553346634,
+          0.7748194504529238,
+          1.2963786721229553,
+          1.8688419833779335,
+          -7.6056107878685,
+          3.294576331973076,
+          -7.1007296442985535,
+          -6.323961913585663,
+          -3.0103983357548714,
+          0.1409937278367579,
+          -1.9777238368988037,
+          -3.283429890871048,
+          -0.8201633580029011,
+          -3.7727858871221542,
+          0,
+          2.232632413506508,
+          7.083704322576523,
+          2.354704774916172,
+          -2.0350223407149315,
+          -3.0145542696118355,
+          -2.8487976640462875,
+          -16.977503895759583,
+          4.476479813456535,
+          -6.949497759342194,
+          1.4966619201004505,
+          3.739132732152939,
+          -25.95657706260681,
+          -3.187382221221924,
+          -0.5704784765839577,
+          0.3707245457917452,
+          -8.255671709775925,
+          15.765897929668427,
+          -5.173716694116592,
+          -4.539374262094498,
+          0.03926255740225315,
+          -0.01611439074622467,
+          -1.379693578928709,
+          2.030264213681221,
+          1.4942270703613758,
+          4.593566060066223,
+          -3.95367331802845,
+          -22.77061492204666,
+          5.6529700756073,
+          -1.0423325933516026,
+          -5.0238750874996185,
+          4.6988919377326965,
+          -2.6057062670588493,
+          -0.7200319785624743,
+          5.382653325796127,
+          0.6544105708599091,
+          1.1035723611712456,
+          5.077438056468964,
+          14.73010778427124,
+          -2.7364419773221016,
+          -1.082111056894064,
+          27.203083038330078,
+          16.853955388069153,
+          -8.552335947751999,
+          14.096322655677795,
+          -3.2765086740255356,
+          12.993219494819641,
+          -5.702397972345352,
+          -32.03296661376953,
+          2.665330283343792,
+          0.30319206416606903,
+          -3.249441459774971,
+          -11.265448480844498,
+          2.9967404901981354,
+          2.6826946064829826,
+          28.039467334747314,
+          -20.852795243263245,
+          -4.159173741936684,
+          -0.6737133953720331,
+          -7.485503703355789,
+          -0.8903210982680321,
+          13.293696939945221,
+          4.764354974031448,
+          -0.008843891555443406,
+          6.243377551436424,
+          0.3104881616309285,
+          -2.5746403262019157,
+          13.892289996147156,
+          -0.35134966019541025,
+          -6.771973520517349,
+          -0.45568710193037987
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "overlay",
+        "height": 500,
+        "legend": {
+         "title": {},
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "font": {
+          "size": 20
+         },
+         "text": "Distribution of Forecast Bias in the dataset",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "top"
+        },
+        "width": 900,
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          -40,
+          40
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Forecast Bias"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0,
+          1
+         ],
+         "matches": "x",
+         "showgrid": true,
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          0.7326
+         ],
+         "title": {
+          "font": {
+           "size": 12
+          },
+          "text": "Probability Density"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0.7426,
+          1
+         ],
+         "matches": "y2",
+         "showgrid": false,
+         "showline": false,
+         "showticklabels": false,
+         "ticks": ""
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.histogram(baseline_metrics_val_df, \n",
+    "                   x=\"Forecast Bias\", \n",
+    "                   color=\"Algorithm\",\n",
+    "                   pattern_shape=\"Algorithm\", \n",
+    "                   marginal=\"box\", \n",
+    "                   nbins=250,\n",
+    "                   barmode=\"overlay\",\n",
+    "                   histnorm=\"probability density\")\n",
+    "fig = format_plot(fig, xlabel=\"Forecast Bias\", ylabel=\"Probability Density\", title=\"Distribution of Forecast Bias in the dataset\")\n",
+    "fig.update_layout(xaxis_range=[-40,40])\n",
+    "# fig.write_image(\"imgs/chapter_4/bias_dist.png\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8563e46a-8c50-4ae4-8321-2a36e9d104d8",
+   "metadata": {},
+   "source": [
+    "## Saving the Baseline Forecasts and Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "330d2005-faba-44da-89a9-29b088758998",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"data/london_smart_meters/output\", exist_ok=True)\n",
+    "output = Path(\"data/london_smart_meters/output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "b93cdcae-b729-42f3-80a8-c6bb368f534f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "baseline_pred_val_df.to_pickle(output/\"single_step_backtesting_baseline_prediction_val_df.pkl\")\n",
+    "baseline_metrics_val_df.to_pickle(output/\"single_step_backtesting_baseline_metrics_val_df.pkl\")\n",
+    "agg_metric_val_df.to_pickle(output/\"single_step_backtesting_baseline_aggregate_metrics_val.pkl\")\n",
+    "baseline_pred_test_df.to_pickle(output/\"single_step_backtesting_baseline_prediction_test_df.pkl\")\n",
+    "baseline_metrics_test_df.to_pickle(output/\"single_step_backtesting_baseline_metrics_test_df.pkl\")\n",
+    "agg_metric_test_df.to_pickle(output/\"single_step_backtesting_baseline_aggregate_metrics_test.pkl\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Updated the baselines to use NIXTLA & cross_validation to build the models.  Had to update ts_utils to add a new forecast_bias function to handle the NIXTLA formatting.
Results match about 99%, for some reason there is an occasional variation between the 2.

