### PR TITLE
Updated yaml to lock install 0.0.8 of datasetsforecast

### DIFF
--- a/anaconda_env.yml
+++ b/anaconda_env.yml
@@ -50,5 +50,6 @@ dependencies:
     - pytorch-lightning>=2.0
     - statsforecast==1.7.8
     - neuralforecast==1.7.4
+    - datasetsforecast==0.0.8
     # - jupyterlab-code-formatter>=1.4.10
     # - aquirdturtle_collapsible_headings>=3.1.0


### PR DESCRIPTION
in datasetsforecast version 1.0, they removed losses folder which had some of the loss functions used in the code.