### PR TITLE
#43 - updated the call to ensure tensors are contiguous 

### DIFF
--- a/anaconda_env.yml
+++ b/anaconda_env.yml
@@ -51,5 +51,6 @@ dependencies:
     - statsforecast==1.7.8
     - neuralforecast==1.7.4
     - datasetsforecast==0.0.8
+    - kaleido==0.2.1
     # - jupyterlab-code-formatter>=1.4.10
     # - aquirdturtle_collapsible_headings>=3.1.0

--- a/src/dl/models.py
+++ b/src/dl/models.py
@@ -91,7 +91,8 @@ class BaseModel(pl.LightningModule, metaclass=ABCMeta):
     def calculate_metrics(self, y, y_hat, tag):
         metrics = []
         for metric, metric_str in zip(self.metrics, self.metrics_name):
-            avg_metric = metric(y_hat, y)
+            #avg_metric = metric(y_hat, y)
+            avg_metric = metric(y_hat.contiguous(), y.contiguous())
             self.log(
                 f"{tag}_{metric_str}",
                 avg_metric,


### PR DESCRIPTION
updated avg_metric = metric(y_hat.contiguous(), y.contiguous())

This should solve the issue. 
Also added kaleido back to environment yaml as it was commented out before, but required for the plot in this notebook.